### PR TITLE
Fix cargo toml deps

### DIFF
--- a/examples/aes/Cargo.toml
+++ b/examples/aes/Cargo.toml
@@ -13,6 +13,7 @@ hacspec-lib = { git = "https://github.com/hacspec/hacspec.git" }
 [dev-dependencies]
 criterion = "0.4"
 rand = "0.8"
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }
 
 [[bench]]
 name = "benchmarks"

--- a/examples/aes128-gcm/Cargo.toml
+++ b/examples/aes128-gcm/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 criterion = "0.4"
 rand = "0.8"
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }
 
 [[bench]]
 name = "benchmarks"

--- a/examples/chacha20/Cargo.toml
+++ b/examples/chacha20/Cargo.toml
@@ -21,7 +21,7 @@ serde = {version = "1.0", features = ["derive"]}
 rayon = "1.3.0"
 criterion = "0.4"
 rand = "0.8"
-hacspec-dev = { path = "../../../hacspec/utils/dev" }
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }
 
 [[bench]]
 name = "benchmarks"

--- a/examples/chacha20poly1305/Cargo.toml
+++ b/examples/chacha20poly1305/Cargo.toml
@@ -23,6 +23,7 @@ serde = {version = "1.0", features = ["derive"]}
 rayon = "1.3.0"
 criterion = "0.4"
 rand = "0.8"
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }
 
 [[bench]]
 name = "benchmarks"

--- a/examples/curve25519/Cargo.toml
+++ b/examples/curve25519/Cargo.toml
@@ -13,6 +13,8 @@ hacspec-lib = { git = "https://github.com/hacspec/hacspec.git" }
 [dev-dependencies]
 criterion = "0.4"
 rand = "0.8"
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }
+
 
 [[bench]]
 name = "benchmarks"

--- a/examples/ecdsa-p256-sha256/Cargo.toml
+++ b/examples/ecdsa-p256-sha256/Cargo.toml
@@ -15,3 +15,4 @@ hacspec-sha256 = { path = "../sha256" }
 [dev-dependencies]
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"]}
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }

--- a/examples/ed25519/Cargo.toml
+++ b/examples/ed25519/Cargo.toml
@@ -19,5 +19,6 @@ quickcheck = "1"
 quickcheck_macros = "1"
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"]}
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }
 
 

--- a/examples/gf128/Cargo.toml
+++ b/examples/gf128/Cargo.toml
@@ -13,6 +13,7 @@ hacspec-lib = { git = "https://github.com/hacspec/hacspec.git" }
 [dev-dependencies]
 criterion = "0.4"
 rand = "0.8"
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }
 
 [[bench]]
 name = "benchmarks"

--- a/examples/gimli/Cargo.toml
+++ b/examples/gimli/Cargo.toml
@@ -11,3 +11,4 @@ path = "src/gimli.rs"
 hacspec-lib = { git = "https://github.com/hacspec/hacspec.git" }
 
 [dev-dependencies]
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }

--- a/examples/p256/Cargo.toml
+++ b/examples/p256/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 criterion = "0.4"
 rand = "0.8"
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }
 
 [[bench]]
 name = "benchmarks"

--- a/examples/poly1305/Cargo.toml
+++ b/examples/poly1305/Cargo.toml
@@ -21,6 +21,7 @@ serde = {version = "1.0", features = ["derive"]}
 rayon = "1.3.0"
 criterion = "0.4"
 rand = "0.8"
+hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
Switch the local path for `hacspec-dev` to a git dependency and propagate it to examples that need it