### PR TITLE
Temporary fix for `derive`d code (fixes #78)

### DIFF
--- a/test-harness/src/harness.rs
+++ b/test-harness/src/harness.rs
@@ -143,14 +143,17 @@ impl Test {
             lazy_static! {
                 // Regex [TIME] matches compile times
                 static ref TIME: Regex = Regex::new(r"\bin \d+(\.\d+)?s\b").unwrap();
+                static ref LOCK: Regex = Regex::new(r"Blocking waiting for \w+ lock on (the registry index|build directory|package cache)").unwrap();
             }
             TIME.replace_all(
-                s.replace(r"\", "/")
-                    .replace(&workspace, "WORKSPACE_ROOT")
-                    .replace("Blocking waiting for file lock on build directory", "")
-                    .trim(),
+                LOCK.replace_all(
+                    &s.replace(r"\", "/").replace(&workspace, "WORKSPACE_ROOT"),
+                    "",
+                )
+                .as_ref(),
                 "in XXs",
             )
+            .trim()
             .to_string()
         };
         let serr = cleanup(String::from_utf8_lossy(&out.stderr).to_string());

--- a/tests/enum-struct-variant/Cargo.toml
+++ b/tests/enum-struct-variant/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 
 [package.metadata.circus-tests]
-into."fstar+coq" = {broken = true, snapshot = "none"}
+into."fstar+coq" = {broken = false, snapshot = "none"}


### PR DESCRIPTION
We want to skip derived implementations for `PartialEq`, `Eq`, `Clone`, `Debug`. This patch filters out every item that was automatically derived. This is a too coarse filter, we need to rework that.