### PR TITLE
Add `--force` flag to `cargo install`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,9 @@
 set -x -e
 
 # Install the Rust CLI & frontend, providing `cargo-hax` and `driver-hax`:
-cargo install --path cli/driver && cargo install --path cli/subcommands
+for i in driver subcommands; do
+    cargo install --force --path "cli/$i";
+done
 
 # Install the OCaml engine:
 OPAMASSUMEDEPEXTS=1 opam install --yes ./engine


### PR DESCRIPTION
This PR adds `--force` flag by default to `setup.sh` so that people can update Hax properly.
Otherwise, `cargo install` sees a binary with the same name, and skips the installation.