### PR TITLE
Small fixes

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -54,10 +54,5 @@ jobs:
         done
       env:
         SKIPLIST: |
-          hacspec-riot-runqueue
-          hacspec-aes-jazz
           tls_cryptolib
           hacspec-merlin
-          hacspec-rsa-pkcs1
-          hacspec-bip-340
-          hacspec-rsa-fdh-vrf

--- a/cli/options/src/lib.rs
+++ b/cli/options/src/lib.rs
@@ -168,7 +168,7 @@ pub struct Options {
         value_parser,
         value_delimiter = ',',
         default_values = [
-            "hacspec_lib::array::array", "hacspec_lib::array::bytes",
+            "hacspec_lib::array::array", "hacspec_lib::array::public_bytes", "hacspec_lib::array::bytes",
             "hacspec_lib::math_integers::public_nat_mod", "hacspec_lib::math_integers::unsigned_public_integer",
         ],
     )]

--- a/engine/backends/coq/coq_backend.ml
+++ b/engine/backends/coq/coq_backend.ml
@@ -881,8 +881,7 @@ struct
         [
           C.AST.Notation
             ( o.bytes_name ^ "_t",
-              C.AST.ArrayTy
-                (C.AST.Int (C.AST.U8, false), (* int_of_string *) o.size) );
+              C.AST.ArrayTy (C.AST.Int (C.AST.U8, false), o.size) );
           C.AST.Definition
             ( o.bytes_name,
               [],
@@ -930,9 +929,7 @@ struct
         } ->
         let open Hacspeclib_macro_parser in
         let o : Bytes.t = Bytes.parse argument |> Result.ok_or_failwith in
-        let typ =
-          C.AST.ArrayTy (C.AST.Int (C.AST.U8, false), (* int_of_string *) o.size)
-        in
+        let typ = C.AST.ArrayTy (C.AST.Int (C.AST.U8, false), o.size) in
         [
           C.AST.Notation (o.bytes_name ^ "_t", typ);
           C.AST.Definition

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -386,6 +386,13 @@ struct
         } ->
         F.term
         @@ F.AST.Project (pexpr arg, F.lid [ "_" ^ string_of_int (n + 1) ])
+    | App
+        {
+          f = { e = GlobalVar (`Projector (`Concrete cid)) };
+          args = [ arg ];
+        } ->
+        F.term
+        @@ F.AST.Project (pexpr arg, pconcrete_ident cid)
     | App { f = { e = GlobalVar x }; args } when Map.mem operators x ->
         let arity, op = Map.find_exn operators x in
         if List.length args <> arity then

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -386,13 +386,9 @@ struct
         } ->
         F.term
         @@ F.AST.Project (pexpr arg, F.lid [ "_" ^ string_of_int (n + 1) ])
-    | App
-        {
-          f = { e = GlobalVar (`Projector (`Concrete cid)) };
-          args = [ arg ];
-        } ->
-        F.term
-        @@ F.AST.Project (pexpr arg, pconcrete_ident cid)
+    | App { f = { e = GlobalVar (`Projector (`Concrete cid)) }; args = [ arg ] }
+      ->
+        F.term @@ F.AST.Project (pexpr arg, pconcrete_ident cid)
     | App { f = { e = GlobalVar x }; args } when Map.mem operators x ->
         let arity, op = Map.find_exn operators x in
         if List.length args <> arity then

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -349,6 +349,7 @@ struct
   let operators =
     let c = GlobalIdent.of_string_exn in
     [
+      (c "core::ops::index::IndexMut::update_at", (3, ".[]<-"));
       (c "std::core::array::update_array_at", (3, ".[]<-"));
       (c "core::ops::index::Index::index", (2, ".[]"));
       (c "core::ops::bit::BitXor::bitxor", (2, "^."));

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -732,6 +732,11 @@ struct
                 F.decls_of_string @@ "unfold type "
                 ^ str_of_type_ident e.span (hacspec_lib_item @@ o.bytes_name)
                 ^ "  = lseq uint8 " ^ o.size
+            | "public_bytes" ->
+                let o = Bytes.parse argument |> unwrap in
+                F.decls_of_string @@ "unfold type "
+                ^ str_of_type_ident e.span (hacspec_lib_item @@ o.bytes_name)
+                ^ "  = lseq uint8 " ^ o.size
             | "array" ->
                 let o = Array.parse argument |> unwrap in
                 let typ =

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -532,6 +532,7 @@ module Exn = struct
                    path = Non_empty_list.[ "ops"; "Index"; "index" ];
                  })
             [ lhs; index ]
+      | StaticRef { def_id = id; _ } -> GlobalVar (def_id id)
       | PlaceTypeAscription _ ->
           unimplemented e.span "expression PlaceTypeAscription"
       | ValueTypeAscription _ ->
@@ -539,7 +540,6 @@ module Exn = struct
       | NonHirLiteral _ -> unimplemented e.span "expression NonHirLiteral"
       | ZstLiteral _ -> unimplemented e.span "expression ZstLiteral"
       | ConstParam _ -> unimplemented e.span "expression ConstParam"
-      | StaticRef _ -> unimplemented e.span "expression StaticRef"
       | Yield _ -> unimplemented e.span "expression Yield"
       | Todo _ -> unimplemented e.span "expression Todo"
     in

--- a/engine/utils/hacspeclib-macro-parser/hacspeclib_macro_parser.ml
+++ b/engine/utils/hacspeclib-macro-parser/hacspeclib_macro_parser.ml
@@ -96,7 +96,10 @@ module Bytes = struct
 
     let parser =
       let* bytes_name = identifier <* comma in
-      let+ size = identifier in
+      let+ size =
+        identifier
+        (* this covers number and constants, but this leads to namespacing issues... *)
+      in
       { bytes_name; size }
 
     let name = "bytes"


### PR DESCRIPTION
Small fixes after #98, notably, update the list of examples that are still failing, so that the CI and #28 reflect the same thing.
Now, only two v1 examples are not extracting: `tls_cryptolib` and `hacspec-merlin`.
