### PR TITLE
Fix performance and process limit issue with `--debug-engine`

### DIFF
--- a/engine/DEV.md
+++ b/engine/DEV.md
@@ -42,3 +42,14 @@ To show the file nicely formated, use: `dune describe pp lib/types.ml` (or `dune
 
 You can also use `dune utop` and then `#show_type Hax_engine.Types.SOME_TYPE` and `#show_constructor Hax_engine.Types.SOME_CONSTRUCTOR`.
 
+## Debugging the phases
+You can enable a debug mode that prints a Rustish AST at each phase,
+that you can browse interactively along with the actual AST.
+
+Just add the flag `--debug-engine DIR` to the `into` subcommand, where
+`DIR` is a directory where will be outputted debug informations. Make
+sure to create the folder beforehand.
+
+To browse the debug information, run
+`./engine/utils/phase_debug_webapp/server.js DIR`. Note you can change
+to port by setting the environment variable `PORT`.

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -77,13 +77,7 @@ let to_thir_span (s : Ast.span) : T.span =
       }
 
 let run_hax_pretty_print_diagnostics (s : string) : string =
-  try
-    let stdout, stdin = Unix.open_process "hax-pretty-print-diagnostics" in
-    Out_channel.(
-      output_string stdin s;
-      flush stdin;
-      close stdin);
-    In_channel.input_all stdout
+  try (Utils.Command.run "hax-pretty-print-diagnostics" s).stdout
   with e ->
     "[run_hax_pretty_print_diagnostics] failed. Exn: " ^ Printexc.to_string e
     ^ ". Here is the JSON representation of the error that occurred:\n" ^ s

--- a/engine/lib/phase_utils.ml
+++ b/engine/lib/phase_utils.ml
@@ -172,7 +172,7 @@ end = struct
              let filename =
                Printf.sprintf "%02d" nth ^ "_" ^ [%show: DebugPhaseInfo.t] k
              in
-             let rustish = List.map ~f:Print_rust.pitem !l in
+             let rustish = Print_rust.pitems !l in
              let json =
                `Assoc
                  [
@@ -180,14 +180,14 @@ end = struct
                    ("nth", `Int nth);
                    ("items", [%yojson_of: Ast.Full.item list] !l);
                    ( "rustish",
-                     [%yojson_of: Print_rust.AnnotatedString.Output.t list]
-                       rustish );
+                     [%yojson_of: Print_rust.AnnotatedString.Output.t] rustish
+                   );
                  ]
              in
              let rustish =
-               List.map ~f:Print_rust.AnnotatedString.Output.raw_string rustish
-               |> String.concat ~sep:"\n\n"
+               Print_rust.AnnotatedString.Output.raw_string rustish
              in
+
              ((filename, rustish), json))
       |> List.unzip
     in

--- a/engine/lib/print_rust.mli
+++ b/engine/lib/print_rust.mli
@@ -9,5 +9,6 @@ module AnnotatedString : sig
 end
 
 val pitem : item -> AnnotatedString.Output.t
+val pitems : item list -> AnnotatedString.Output.t
 val pitem_str : item -> string
 val pexpr_str : expr -> string

--- a/engine/lib/utils.ml
+++ b/engine/lib/utils.ml
@@ -42,3 +42,23 @@ let split_str (s : string) ~(on : string) : string list =
 
 let tabsize = 2
 let newline_indent depth : string = "\n" ^ String.make (tabsize * depth) ' '
+
+module Command = struct
+  type output = { stderr : string; stdout : string }
+
+  let run (command : string) (stdin_string : string) : output =
+    let stdout, stdin, stderr =
+      Unix.open_process_full command (Unix.environment ())
+    in
+    Unix.set_close_on_exec @@ Unix.descr_of_in_channel stdout;
+    Unix.set_close_on_exec @@ Unix.descr_of_in_channel stderr;
+    Out_channel.(
+      output_string stdin stdin_string;
+      flush stdin;
+      close stdin);
+    let strout = In_channel.input_all stdout in
+    let strerr = In_channel.input_all stderr |> Caml.String.trim in
+    Unix.close @@ Unix.descr_of_in_channel stdout;
+    Unix.close @@ Unix.descr_of_in_channel stderr;
+    { stdout = strout; stderr = strerr }
+end

--- a/engine/utils/phase_debug_webapp/script.js
+++ b/engine/utils/phase_debug_webapp/script.js
@@ -263,7 +263,7 @@ async function phases_viewer(state = {index: 0, ast_focus: null, seed: SEED}) {
     let app_root = document.querySelector('#app');
     app_root.childNodes.forEach(old => old.remove());
     app_root.appendChild(main);
-    app_root.onkeydown = (e) => {
+    document.body.onkeydown = (e) => {
         let key = ({'ArrowRight': 'n', 'ArrowLeft': 'p'})[e.key] || e.key;
         (({
             'n': () => phases_viewer({...state, index: state.index + 1, ast_focus: null}),

--- a/engine/utils/phase_debug_webapp/script.js
+++ b/engine/utils/phase_debug_webapp/script.js
@@ -193,7 +193,7 @@ async function phases_viewer(state = {index: 0, ast_focus: null, seed: SEED}) {
         header.appendChild(container);
     }
     let last_item = null;
-    let codes = current.rustish.map(({string, map}) => {
+    let codes = [current.rustish].map(({string, map}) => {
         let src = string;
         let code = mk('code', [], ['language-rust']);
         code.innerHTML = Prism.highlight(src, Prism.languages.rust, 'rust');


### PR DESCRIPTION
Fixes `--debug-engine` `EMFILE` issues, and optimize a bit perfs.

More specifically:
 - I was not closing processes correctly in OCaml while `rustfmt` items;
 - (in debug mode) now I run one `rustfmt` for each phase, before the engine was running `n` `rustfmt`s for each phase, with `n` the number of items.