### PR TITLE
Remove specific code for `[x; LEN]`, use general const to expr

### DIFF
--- a/tests/generics/src/lib.rs
+++ b/tests/generics/src/lib.rs
@@ -11,3 +11,7 @@ fn foo<const LEN: usize>(arr: [usize; LEN]) -> usize {
     }
     acc
 }
+
+fn repeat<const LEN: usize, T: Copy>(x: T) -> [T; LEN] {
+    [x; LEN]
+}


### PR DESCRIPTION
Fixes the construction of arrays `[x; LEN]` when `LEN` is not a literal.