### PR TITLE
Make `Steal` error recoverable, make more errors non-fatal

### DIFF
--- a/cli/driver/src/exporter.rs
+++ b/cli/driver/src/exporter.rs
@@ -59,7 +59,6 @@ fn convert_thir<'tcx>(
         .map(|did| {
             let span = hir.span(hir.local_def_id_to_hir_id(did));
             let mk_error_thir = || {
-                // let ty = tcx.ty_error(error);
                 let ty = tcx.mk_ty_from_kind(rustc_type_ir::sty::TyKind::Never);
                 let mut thir = rustc_middle::thir::Thir::new(rustc_middle::thir::BodyTy::Const(ty));
                 const ERR_LITERAL: &'static rustc_hir::Lit = &rustc_span::source_map::Spanned {

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -1,5 +1,6 @@
 open Base
 open Utils
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 module Non_empty_list = struct
   include Non_empty_list

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -1,4 +1,5 @@
 open Base
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 open Utils
 open Ast
 

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -1,4 +1,5 @@
 open Utils
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 module T = Types
 
 module Backend = struct

--- a/engine/lib/feature_gate.ml
+++ b/engine/lib/feature_gate.ml
@@ -1,4 +1,5 @@
 open Base
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 open Utils
 
 module DefaultSubtype = struct

--- a/engine/lib/phase_utils.ml
+++ b/engine/lib/phase_utils.ml
@@ -1,4 +1,5 @@
 open Base
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 module Metadata : sig
   type t = private {

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -1,4 +1,5 @@
 open Base
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 open Ast
 open Ast.Full
 open Utils

--- a/engine/utils/hacspeclib-macro-parser/hacspeclib_macro_parser.ml
+++ b/engine/utils/hacspeclib-macro-parser/hacspeclib_macro_parser.ml
@@ -1,5 +1,6 @@
 open! Base
 open Angstrom
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 module BasicParsers = struct
   let is_space = function ' ' | '\t' | '\n' -> true | _ -> false

--- a/frontend/exporter/src/all.rs
+++ b/frontend/exporter/src/all.rs
@@ -2543,7 +2543,6 @@ pub enum ExprKind {
     },
     /// A `&raw [const|mut] $place_expr` raw borrow resulting in type `*[const|mut] T`.
     AddressOf {
-        #[map(fatal!(gstate, "AddressOf"))]
         mutability: Mutability,
         arg: Expr,
     },

--- a/frontend/exporter/src/items.rs
+++ b/frontend/exporter/src/items.rs
@@ -798,7 +798,14 @@ impl<'tcx, S: BaseState<'tcx> + HasOwnerId> SInto<S, GenericBounds>
                 let pred: rustc_middle::ty::Predicate = pred.clone();
                 let kind: rustc_middle::ty::Binder<'_, rustc_middle::ty::PredicateKind> =
                     pred.kind();
-                let kind: rustc_middle::ty::PredicateKind = kind.no_bound_vars().unwrap();
+                let kind: rustc_middle::ty::PredicateKind =
+                    kind.no_bound_vars().unwrap_or_else(|| {
+                        tcx.sess.span_err(
+                            span.clone(),
+                            format!("[GenericBounds]: [no_bound_vars] failed"),
+                        );
+                        rustc_middle::ty::PredicateKind::Ambiguous
+                    });
                 kind.sinto(s)
             })
             .collect()


### PR DESCRIPTION
I found some other code that triggers the steal error.
This PR makes the error recoverable using some unsafe things: we report an error but keep going.