### PR TITLE
Frontend: transform `NonHirLiteral` into `Literal` (fixes #162)

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -570,7 +570,6 @@ module Exn = struct
           unimplemented e.span "expression PlaceTypeAscription"
       | ValueTypeAscription _ ->
           unimplemented e.span "expression ValueTypeAscription"
-      | NonHirLiteral _ -> unimplemented e.span "expression NonHirLiteral"
       | ZstLiteral _ -> unimplemented e.span "expression ZstLiteral"
       | Yield _ -> unimplemented e.span "expression Yield"
       | Todo _ -> unimplemented e.span "expression Todo"

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -18,6 +18,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "enum-repr"
+version = "0.1.0"
+
+[[package]]
 name = "enum-struct-variant"
 version = "0.1.0"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,6 +4,7 @@ members = [
         "literals",
         "slices",
         "if-let",
+        "enum-repr",
         "side-effects",
         "lint/hacspec/v1-lib",
         "lint/hacspec/mut_args",

--- a/tests/enum-repr/Cargo.toml
+++ b/tests/enum-repr/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "enum-repr"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.hax-tests]
+into."fstar+coq" = { broken = false, snapshot = "none", issue_id = "162" }

--- a/tests/enum-repr/src/lib.rs
+++ b/tests/enum-repr/src/lib.rs
@@ -1,0 +1,14 @@
+#![allow(dead_code)]
+
+#[repr(u16)]
+enum Foo {
+    A = 1,
+    B = 5,
+    C = 9,
+}
+
+fn f() -> u16 {
+    const CONST: u16 = Foo::A as u16;
+    let _x = Foo::B as u16;
+    Foo::C as u16
+}


### PR DESCRIPTION
This PR transforms `NonHirLiteral`s into "normal" literals in the frontend.
Thus, this removes NonHirLiteral from THIR' (the JSON one).