### PR TITLE
Switch from `cachix` to `DeterminateSystems/magic-nix-cache`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v20
+    - uses: DeterminateSystems/nix-installer-action@main
     - name: Run OCaml formatter
       run: |
         nix shell ..#ocamlformat -c \
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v20
+    - uses: DeterminateSystems/nix-installer-action@main
     - name: Run Rust formatter
       run: |
         nix shell nixpkgs#rustfmt -c \

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -12,11 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v20
-    - uses: cachix/cachix-action@v12
-      with:
-        name: hacspec
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Build
       run: nix build -L
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,8 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v20
-    - uses: cachix/cachix-action@v12
-      with:
-        name: hacspec
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Build JS
       run: nix build .#hax-engine.passthru.js -L -o hax-engine.js
 


### PR DESCRIPTION
Simplifies a bit the CI & should improve performances.
This replaces [Cachix](https://app.cachix.org/cache/hacspec) with https://github.com/DeterminateSystems/magic-nix-cache, that uses Github Actions cache.
That's less configuration and fetching cache should be faster.