### PR TITLE
Improve a bit error messages & codes

### DIFF
--- a/cli/options/engine/src/lib.rs
+++ b/cli/options/engine/src/lib.rs
@@ -16,6 +16,6 @@ pub struct File {
 
 #[derive(JsonSchema, Debug, Clone, Serialize, Deserialize)]
 pub struct Output {
-    pub diagnostics: Vec<hax_diagnostics::Diagnostics<hax_frontend_exporter::Span>>,
+    pub diagnostics: Vec<hax_diagnostics::Diagnostics<Vec<hax_frontend_exporter::Span>>>,
     pub files: Vec<File>,
 }

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -22,8 +22,6 @@ type span = (Span.t[@visitors.opaque])
     visitors { variety = "mapreduce"; name = "span_mapreduce" },
     visitors { variety = "map"; name = "span_map" }]
 
-type loc = Span.loc [@@deriving show, yojson, compare, sexp, eq]
-
 type concrete_ident = (Concrete_ident.t[@visitors.opaque])
 [@@deriving
   show,

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -398,8 +398,9 @@ module Make (F : Features.T) = struct
 
   let make_tuple_pat' (pats : pat list) : pat =
     let len = List.length pats in
+    let span = Span.union_list @@ List.map ~f:(fun p -> p.span) pats in
     List.mapi ~f:(fun i pat -> { field = `TupleField (i, len); pat }) pats
-    |> make_tuple_pat'' (Span.union_list @@ List.map ~f:(fun p -> p.span) pats)
+    |> make_tuple_pat'' span
 
   let make_tuple_pat : pat list -> pat = function
     | [ pat ] -> pat
@@ -483,19 +484,24 @@ module Make (F : Features.T) = struct
     let item : AST.expr -> Ast.Full.expr = Obj.magic
   end
 
-  let unbox_expr (e : expr) : expr =
+  let unbox_expr' (next : expr -> expr) (e : expr) : expr =
     match e.e with
     | App { f = { e = GlobalVar f; _ }; args = [ e ] }
       when Global_ident.eq_name Alloc__boxed__Impl__new f ->
-        e
+        next e
     | _ -> e
 
-  let underef_expr (e : expr) : expr =
+  let underef_expr' (next : expr -> expr) (e : expr) : expr =
     match e.e with
-    | App { f = { e = GlobalVar (`Primitive Ast.Deref); _ }; args = [ e ] } -> e
+    | App { f = { e = GlobalVar (`Primitive Ast.Deref); _ }; args = [ e ] } ->
+        next e
     | _ -> e
 
-  let unbox_underef_expr = unbox_expr >> underef_expr
+  let rec unbox_expr e = unbox_expr' unbox_expr e
+  let rec underef_expr e = underef_expr' unbox_expr e
+
+  let rec unbox_underef_expr e =
+    (unbox_expr' unbox_underef_expr >> underef_expr' unbox_underef_expr) e
 
   (* module Box = struct *)
   (*   module Ty = struct *)

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -66,10 +66,10 @@ end
 
 type kind = T.kind [@@deriving show, eq]
 
-type t = { context : Context.t; kind : kind; span : T.span }
+type t = { context : Context.t; kind : kind; span : T.span list }
 [@@deriving show, eq]
 
-let to_thir_diagnostic (d : t) : Types.diagnostics_for__span =
+let to_thir_diagnostic (d : t) : Types.diagnostics_for__array_of__span =
   { kind = d.kind; context = Context.display d.context; span = d.span }
 
 let run_hax_pretty_print_diagnostics (s : string) : string =
@@ -79,7 +79,7 @@ let run_hax_pretty_print_diagnostics (s : string) : string =
     ^ ". Here is the JSON representation of the error that occurred:\n" ^ s
 
 let pretty_print : t -> string =
-  to_thir_diagnostic >> Types.to_json_diagnostics_for__span
+  to_thir_diagnostic >> Types.to_json_diagnostics_for__array_of__span
   >> Yojson.Safe.pretty_to_string >> run_hax_pretty_print_diagnostics
 
 let pretty_print_context_kind : Context.t -> kind -> string =

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -55,6 +55,13 @@ module Context = struct
     | DebugPrintRust
     | Other of string
   [@@deriving show, eq, yojson]
+
+  let display = function
+    | Phase p -> Phase.display p
+    | Backend backend -> [%show: Backend.t] backend ^ " backend"
+    | ThirImport -> "AST import"
+    | DebugPrintRust -> "Rust debug printer"
+    | Other s -> "Other (" ^ s ^ ")"
 end
 
 type kind = T.kind [@@deriving show, eq]
@@ -63,7 +70,7 @@ type t = { context : Context.t; kind : kind; span : T.span }
 [@@deriving show, eq]
 
 let to_thir_diagnostic (d : t) : Types.diagnostics_for__span =
-  { kind = d.kind; context = [%show: Context.t] d.context; span = d.span }
+  { kind = d.kind; context = Context.display d.context; span = d.span }
 
 let run_hax_pretty_print_diagnostics (s : string) : string =
   try (Utils.Command.run "hax-pretty-print-diagnostics" s).stdout

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -68,7 +68,7 @@ module Raw = struct
     pure span
     @@
     match e with
-    | String s -> "\"" ^ s ^ "\""
+    | String s -> "\"" ^ String.escaped s ^ "\""
     | Char c -> "'" ^ Char.to_string c ^ "'"
     | Int { value; _ } -> value
     | Float { value; kind = F32 } -> value ^ "f32"

--- a/engine/lib/span.mli
+++ b/engine/lib/span.mli
@@ -1,10 +1,9 @@
-type loc [@@deriving show, yojson, sexp, compare, eq]
-type t [@@deriving show, yojson, sexp, compare, eq]
+(* type loc [@@deriving show, yojson, sexp, compare, eq, hash] *)
+type t [@@deriving show, yojson, sexp, compare, eq, hash]
 
-val of_thir_loc : Types.loc -> loc
+val display : t -> string
 val of_thir : Types.span -> t
-val to_thir_loc : loc -> Types.loc
-val to_thir : t -> Types.span
+val to_thir : t -> Types.span list
 val union_list : t list -> t
 val union : t -> t -> t
 val dummy : unit -> t

--- a/frontend/diagnostics/src/lib.rs
+++ b/frontend/diagnostics/src/lib.rs
@@ -134,6 +134,6 @@ impl Kind {
 
     pub fn code(&self) -> String {
         // `C` stands for `hax`
-        format!("CE{:0>4}", self.discriminant())
+        format!("HAX{:0>4}", self.discriminant())
     }
 }

--- a/frontend/diagnostics/src/lib.rs
+++ b/frontend/diagnostics/src/lib.rs
@@ -163,7 +163,6 @@ impl Kind {
     }
 
     pub fn code(&self) -> String {
-        // `C` stands for `hax`
         format!("HAX{:0>4}", self.discriminant())
     }
 }

--- a/frontend/diagnostics/src/lib.rs
+++ b/frontend/diagnostics/src/lib.rs
@@ -43,11 +43,11 @@ impl<S> Diagnostics<S> {
 
 impl<S> std::fmt::Display for Diagnostics<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}:", self.context);
         match &self.kind {
             Kind::Unimplemented { issue_id, details } => write!(
                 f,
-                "{}: something is not implemented yet.{}{}",
-                self.context,
+                "something is not implemented yet.{}{}",
                 match issue_id {
                     Some(id) => format!("This is discussed in issue https://github.com/hacspec/hacspec-v2/issues/{id}.\nPlease upvote or comment this issue if you see this error message."),
                     _ => "".to_string(),
@@ -81,7 +81,7 @@ impl<S> std::fmt::Display for Diagnostics<S> {
                 bindings
             ),
             Kind::ArbitraryLHS => write!(f, "Assignation of an arbitrary left-hand side is not supported. [lhs = e] is fine only when [lhs] is a combination of local identifiers, field accessors and index accessors."),
-            _ => write!(f, "{}: {:?}", self.context, self.kind),
+            _ => write!(f, "{:?}", self.kind),
         }
     }
 }

--- a/tests/nested-derefs/Cargo.toml
+++ b/tests/nested-derefs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nested-derefs"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.hax-tests]
+into."fstar+coq" = { snapshot = "none" }

--- a/tests/nested-derefs/src/lib.rs
+++ b/tests/nested-derefs/src/lib.rs
@@ -1,0 +1,6 @@
+fn f(x: &usize) -> usize {
+    *x
+}
+fn g(x: &&usize) -> usize {
+    f(*x)
+}


### PR DESCRIPTION
- Error messages were not reporting their context (at which phase the error was raised)
- `CE00XX` was standing for circus error, renamed that into `HAX00XX`