### PR TITLE
Fix `unbox_expr` and `underef_expr` when nested box/deref exprs

### DIFF
--- a/tests/nested-derefs/Cargo.toml
+++ b/tests/nested-derefs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nested-derefs"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.hax-tests]
+into."fstar+coq" = { snapshot = "none" }

--- a/tests/nested-derefs/src/lib.rs
+++ b/tests/nested-derefs/src/lib.rs
@@ -1,0 +1,6 @@
+fn f(x: &usize) -> usize {
+    *x
+}
+fn g(x: &&usize) -> usize {
+    f(*x)
+}


### PR DESCRIPTION
Expressions are now un`box`ed and un`deref`ed as much as possible instead of only once.

**Merge me after #172**