### PR TITLE
Concrete idents: per-backend name policies & reserved words for F*

### DIFF
--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -609,12 +609,19 @@ module Make (F : Features.T) = struct
     include U
     module Map = Map.M (U)
   end
+end
+
+module MakeWithNamePolicy (F : Features.T) (NP : Concrete_ident.NAME_POLICY) =
+struct
+  include Make (F)
+  open AST
+  module Concrete_ident_view = Concrete_ident.MakeViewAPI (NP)
 
   let group_items_by_namespace (items : item list) : item list StringList.Map.t
       =
     let h = Hashtbl.create (module StringList) in
     List.iter items ~f:(fun item ->
-        let ns = Concrete_ident.to_namespace item.ident in
+        let ns = Concrete_ident_view.to_namespace item.ident in
         let items = Hashtbl.find_or_add h ns ~default:(fun _ -> ref []) in
         items := !items @ [ item ]);
     Map.of_iteri_exn

--- a/engine/lib/concrete_ident/concrete_ident.mli
+++ b/engine/lib/concrete_ident/concrete_ident.mli
@@ -20,8 +20,15 @@ val eq_name : name -> t -> bool
 
 type view = { crate : string; path : string list; definition : string }
 
-val to_view : t -> view
-val to_definition_name : t -> string
-val to_crate_name : t -> string
-val to_namespace : t -> string * string list
 val map_path_strings : f:(string -> string) -> t -> t
+
+include module type of struct
+  include Concrete_ident_sig.Make (struct
+    type t_ = t
+    type view_ = view
+  end)
+end
+
+module MakeViewAPI (NP : NAME_POLICY) : VIEW_API
+module DefaultNamePolicy : NAME_POLICY
+module DefaultViewAPI : VIEW_API

--- a/engine/lib/concrete_ident/concrete_ident_sig.ml
+++ b/engine/lib/concrete_ident/concrete_ident_sig.ml
@@ -1,0 +1,23 @@
+open Base
+
+module Make (T : sig
+  type t_
+  type view_
+end) =
+struct
+  open T
+
+  module type NAME_POLICY = sig
+    val reserved_words : string Hash_set.t
+    (** List of all words that have a special meaning in the target
+        language, and that should thus be escaped. *)
+  end
+
+  module type VIEW_API = sig
+    val show : t_ -> string
+    val to_view : t_ -> view_
+    val to_definition_name : t_ -> string
+    val to_crate_name : t_ -> string
+    val to_namespace : t_ -> string * string list
+  end
+end

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -3,6 +3,7 @@ open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 open Ast
 open Ast.Full
 open Utils
+module Concrete_ident_view = Concrete_ident.DefaultViewAPI
 
 module AnnotatedString = struct
   module T = struct
@@ -106,7 +107,7 @@ module Raw = struct
 
   let last_of_global_ident (g : global_ident) span =
     match g with
-    | `Concrete c -> Concrete_ident.to_definition_name c
+    | `Concrete c -> Concrete_ident_view.to_definition_name c
     | _ ->
         Diagnostics.report
           {
@@ -329,7 +330,7 @@ module Raw = struct
           |> concat ~sep:!","
         in
         !"fn "
-        & !(Concrete_ident.to_definition_name name)
+        & !(Concrete_ident_view.to_definition_name name)
         & !"(" & params & !") -> " & return_type & !"{" & pexpr body & !"}"
     | _ -> !"/* TO DO */"
 end


### PR DESCRIPTION
Inspecting a concrete ident is now done up to a *name policy*.
For now, a name policy only consists in a set of reserved words that should be escaped.