### PR TITLE
Fix missed `pp` (used when `[%show: Concrete_ident.t]`ing)

### DIFF
--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -154,8 +154,7 @@ module View = struct
 end
 
 module T = struct
-  type t = { def_id : Imported.def_id; kind : Kind.t }
-  [@@deriving show, yojson, sexp]
+  type t = { def_id : Imported.def_id; kind : Kind.t } [@@deriving yojson, sexp]
 
   (* [kind] is really a metadata, it is not relevant, `def_id`s are unique *)
   let equal x y = [%equal: Imported.def_id] x.def_id y.def_id

--- a/engine/lib/concrete_ident/concrete_ident_sig.ml
+++ b/engine/lib/concrete_ident/concrete_ident_sig.ml
@@ -15,6 +15,7 @@ struct
 
   module type VIEW_API = sig
     val show : t_ -> string
+    val pp : Format.formatter -> t_ -> unit
     val to_view : t_ -> view_
     val to_definition_name : t_ -> string
     val to_crate_name : t_ -> string


### PR DESCRIPTION
PR #177 introduced a bug in the rust formatter: the concrete idents were printed using the wrong printer