### PR TITLE
Explicitly disable the (required) jobs `docker` and `setup_sh` for

### DIFF
--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -1,6 +1,7 @@
 name: Test installations
 
 on:
+  pull_request:
   merge_group:
   workflow_dispatch:
   push:
@@ -8,11 +9,13 @@ on:
     
 jobs:
   docker:
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - run: docker build -f .docker/Dockerfile . -t hacspec-v2
   setup_sh:
+    if: ${{ github.event_name == 'merge_group' }}
     strategy:
       matrix:
         os:


### PR DESCRIPTION
anything else but merge groups.

The idea comes from https://github.com/bevyengine/bevy/issues/7824#issuecomment-1562380615.