### PR TITLE
Add a `setup_sh_status` job

### DIFF
--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -44,3 +44,16 @@ jobs:
     - run: |
         eval $(opam env)
         cargo hax -C -p hacspec-chacha20 \; -i '**' into fstar
+  setup_sh_status:
+    if: |
+      always() &&
+      github.event_name == 'merge_group'
+    needs: setup_sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Failing
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
We need `setup_sh (OS)` with `OS` being `ubuntu-latest`, `ubuntu-20.04` , `macos-latest` or `macos-11` to be required jobs.

But we need to skip those jobs in PRs, so that they are triggered only when in merge queue. This is done with an `if`, but it operates only on jobs, not on matrix instances, so we cannot disable `setup_sh (OS)`, only `setup_sh` itself.

Then:
 - if we set `setup_sh (OS)` as required jobs, that's not fine since only `setup_sh` is reported as skipped (`setup_sh (OS)` don't get reported at all);
 - if we set `setup_sh` as a required job, then, we're able to push PRs to the merge queue, but once it's in the merge queue, GH doesn't create a `setup_sh` at all, only `setyp_sh (OS)`.

Whence this solution: a `setup_sh_status` job that aggregates the status of our 4 `setup_sh (OS)`, succeding when the 4 success, failing otherwise. `setup_sh_status` is the required job, instead of `setup_sh*`.