### PR TITLE
Add `Ast_utils.add_typ_ascription`

### DIFF
--- a/engine/backends/fstar/fstar_ast.ml
+++ b/engine/backends/fstar/fstar_ast.ml
@@ -87,3 +87,5 @@ let decls_of_string s =
 
 let decl_of_string s =
   match decls_of_string s with [ d ] -> d | _ -> failwith "decl_of_string"
+
+let ascribe t e = term @@ AST.Ascribed (e, t, None, false)

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -843,3 +843,4 @@ module TransformToInputLanguage =
 let apply_phases (bo : BackendOptions.t) (items : Ast.Rust.item list) :
     AST.item list =
   TransformToInputLanguage.ditems items
+  |> List.map ~f:U.Mappers.add_typ_ascription


### PR DESCRIPTION
This utils adds type ascription nodes in nested function calls. This helps type inference in the presence of associated types in backends that don't support them well (F* for instance).

Examples:
  - `f (g x)` is turned into `f (g x <: τ)`;
  - `f (let x = g x in x)` is left unchanged (the F* backend annotates `let` already);
  - `f x + g x` is turned into `(f x <: τ₁) + (g x <: τ₂)`;
  - `f (g x <: τ)` is left unchanged (`g x` already has a type ascription).

(edit: there is no test for this since; that's backend-specific and it's noticeable only while F* typechecking)