### PR TITLE
Add `rebuild` script for development

### DIFF
--- a/.utils/rebuild.sh
+++ b/.utils/rebuild.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# This is a small script to rebuild Hax (the Rust CLI & frontend and
+# OCaml engine) quickly
+
+set -euo pipefail
+
+TARGETS="${1:-rust ocaml}"
+
+cd_rootwise () {
+    cd $(git rev-parse --show-toplevel)/$1
+}
+
+rust () {
+    cd_rootwise "cli"
+    for i in driver subcommands; do
+        CURRENT="rust/$i"
+        cargo install --quiet --offline --debug --path $i
+    done
+}
+
+ocaml () {
+    cd_rootwise "engine"
+    CURRENT="ocaml"
+    dune build
+    CURRENT="ocaml/install"
+    # Small hack for those that are not using [opam] at all: by
+    # default install OCaml binaries in `~/.cargo` (which is supposed
+    # to be in PATH anyway).
+    DUNE_INSTALL_PREFIX="${DUNE_INSTALL_PREFIX:-$HOME/.cargo}"
+    dune install --profile dev --prefix $DUNE_INSTALL_PREFIX
+}
+
+GREEN=42
+RED=41
+status () { echo -e "\e[1m[rebuild script] \e[30m\e[$1m$2\e[0m"; }
+
+on_exit () {
+    if [ $? -ne 0 ]; then
+        status $RED "ERR: $CURRENT";
+    fi
+}
+trap on_exit                EXIT ERR
+trap "status $RED 'SIGINT'" SIGINT
+
+CURRENT="none"
+if [[ "$TARGETS" == *rust* ]]; then
+    rust
+    status $GREEN "rust succeed"
+fi
+if [[ "$TARGETS" == *ml* ]]; then
+    ocaml
+    status $GREEN "ocaml succeed"
+fi
+

--- a/README.md
+++ b/README.md
@@ -77,3 +77,8 @@ You can also just use [direnv](https://github.com/nix-community/nix-direnv), wit
 - `engine/`: the simplication and elaboration engine that translate
   programs from the Rust language to various backends (see `engine/backends/`).
 - `cli/`: the `hax` subcommand for Cargo.
+
+### Recompiling
+You can use the [`.utils/rebuild.sh`](./.utils/rebuild.sh) script (which is available automatically as the command `rebuild` when using the Nix devshell):
+ - `rebuild`: rebuild the Rust then the OCaml part;
+ - `rebuild TARGET`: rebuild the `TARGET` part (`TARGET` is either `rust` or `ocaml`).

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,15 @@
               pkgs.pkg-config
               pkgs.rust-analyzer
               rustc
+
+              (pkgs.stdenv.mkDerivation {
+                name = "rebuild-script";
+                phases = [ "installPhase" ];
+                installPhase = ''
+                  mkdir -p $out/bin
+                  cp ${./.utils/rebuild.sh} $out/bin/rebuild
+                '';
+              })
             ];
             LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
           };


### PR DESCRIPTION
Adds a `rebuild.sh` script (in a new `.utils` folder) that compiles the different parts Hax in dev mode in the right order from wherever in the repo.