### PR TITLE
Accept zero-arm matches, insert `never_to_any` coercition 

### DIFF
--- a/engine/backends/coq/coq/coq_backend.ml
+++ b/engine/backends/coq/coq/coq_backend.ml
@@ -165,7 +165,6 @@ struct
     | TChar -> __TODO_ty__ span "char"
     | TInt k -> C.AST.Int (pint_kind k)
     | TStr -> __TODO_ty__ span "str"
-    | TFalse -> __TODO_ty__ span "false"
     | TApp { ident = `TupleType 0 as ident; args = [] } -> C.AST.Unit
     | TApp { ident = `TupleType 1; args = [ GType ty ] } -> pty span ty
     | TApp { ident = `TupleType n; args } when n >= 2 ->

--- a/engine/backends/easycrypt/easycrypt_backend.ml
+++ b/engine/backends/easycrypt/easycrypt_backend.ml
@@ -178,7 +178,6 @@ let translate' (bo : BackendOptions.t) (items : AST.item list) : Types.file list
     | TSlice _ -> assert false
     | TRawPointer _ -> assert false
     | TRef _ -> assert false
-    | TFalse -> assert false
     | TParam _ -> assert false
     | TArrow (_, _) -> assert false
     | TProjectedAssociatedType _ -> assert false

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -222,7 +222,6 @@ struct
     | TChar -> F.term_of_lid [ "char" ]
     | TInt k -> F.term_of_lid [ show_int_kind k ]
     | TStr -> F.term_of_lid [ "string" ]
-    | TFalse -> F.term_of_lid [ "never" ]
     | TSlice { ty; _ } -> F.mk_e_app (F.term_of_lid [ "slice" ]) [ pty span ty ]
     | TApp { ident = `TupleType 0 as ident; args = [] } ->
         F.term @@ F.AST.Name (pglobal_ident span ident)

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -238,7 +238,6 @@ functor
           typ : ty;
           mut : (F.mutable_reference mutability[@visitors.opaque]);
         }
-      | TFalse
       | TParam of local_ident
       | TArrow of ty list * ty
       | TProjectedAssociatedType of string

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -324,13 +324,16 @@ module Make (F : Features.T) = struct
         LocalIdent.var_id_of_int (-1);
     }
 
-  (** Computes the [meet] of a list of types. Basically, [⊥ ⊓ τ] is
-      [τ], [τ ⊓ τ] is [τ], and anything else isn't defined. In the
-      implementation, we just return the first non-[⊥] type, and [⊥]
-      if there is none. Note [⊥] is noted [!] in Rust and correspond
-      to [TFalse] in Hax's AST. *)
-  let meet_types : ty list -> ty =
-    List.find ~f:([%matches? TFalse] >> not) >> Option.value ~default:TFalse
+  let never_typ : ty =
+    let ident =
+      `Concrete (Concrete_ident.of_name Type Rust_primitives__hax__Never)
+    in
+    TApp { ident; args = [] }
+
+  let is_never_typ : ty -> bool = function
+    | TApp { ident; _ } ->
+        Global_ident.eq_name Rust_primitives__hax__Never ident
+    | _ -> false
 
   let unit_typ : ty = TApp { ident = `TupleType 0; args = [] }
 

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -324,6 +324,14 @@ module Make (F : Features.T) = struct
         LocalIdent.var_id_of_int (-1);
     }
 
+  (** Computes the [meet] of a list of types. Basically, [⊥ ⊓ τ] is
+      [τ], [τ ⊓ τ] is [τ], and anything else isn't defined. In the
+      implementation, we just return the first non-[⊥] type, and [⊥]
+      if there is none. Note [⊥] is noted [!] in Rust and correspond
+      to [TFalse] in Hax's AST. *)
+  let meet_types : ty list -> ty =
+    List.find ~f:([%matches? TFalse] >> not) >> Option.value ~default:TFalse
+
   let unit_typ : ty = TApp { ident = `TupleType 0; args = [] }
 
   let unit_expr span : expr =

--- a/engine/lib/concrete_ident/names.rs
+++ b/engine/lib/concrete_ident/names.rs
@@ -105,8 +105,10 @@ mod hax {
 
     fn repeat() {}
     fn update_at() {}
-    // TODO: Should that live here: this is F* specific
+    // TODO: Should that live here? (this is F* specific)
     fn array_of_list() {}
+
+    fn never_to_any() {}
 
     mod control_flow_monad {
         trait ControlFlowMonad {

--- a/engine/lib/concrete_ident/names.rs
+++ b/engine/lib/concrete_ident/names.rs
@@ -102,6 +102,7 @@ fn unsize() {}
 mod hax {
     fn failure() {}
     struct Failure;
+    enum Never {}
 
     fn repeat() {}
     fn update_at() {}

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -770,7 +770,7 @@ module Exn = struct
           let typ = c_ty span ty in
           let mut = c_mutability W.mutable_reference mut in
           TRef { witness = W.reference; region = "todo"; typ; mut }
-      | Never -> TFalse
+      | Never -> U.never_typ
       | Tuple types ->
           let types = List.map ~f:(fun ty -> GType (c_ty span ty)) types in
           TApp { ident = `TupleType (List.length types); args = types }

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -359,7 +359,11 @@ module Exn = struct
               (mk_global ([ source_type ] ->. typ) @@ `Primitive Cast)
               [ source ]
         | Use { source } -> (c_expr source).e
-        | NeverToAny { source } -> (c_expr source).e
+        | NeverToAny { source } ->
+            (U.call Rust_primitives__hax__never_to_any
+               [ c_expr source ]
+               span typ)
+              .e
         (* TODO: this is incorrect (NeverToAny) *)
         | Pointer { cast; source } -> c_pointer e typ span cast source
         | Loop { body } ->

--- a/engine/lib/phases/phase_cf_into_monads.ml
+++ b/engine/lib/phases/phase_cf_into_monads.ml
@@ -186,7 +186,7 @@ struct
                 arms
           in
           let typ =
-            match arms with [] -> B.TFalse | hd :: _ -> hd.arm.body.typ
+            match arms with [] -> UB.never_typ | hd :: _ -> hd.arm.body.typ
           in
           { e = Match { scrutinee = dexpr scrutinee; arms }; span; typ }
       | If { cond; then_; else_ } ->

--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -63,7 +63,7 @@ struct
       | PDeref { subpat; _ } -> (dpat subpat).p
 
     and dexpr' (span : span) (e : A.expr') : B.expr' =
-      match (UA.unbox_underef_expr { e; span; typ = TFalse }).e with
+      match (UA.unbox_underef_expr { e; span; typ = UA.never_typ }).e with
       | [%inline_arms If + Literal + Array + App] -> auto
       | App { f; args } -> App { f = dexpr f; args = List.map ~f:dexpr args }
       | Construct { constructor; is_record; is_struct; fields; base } ->

--- a/engine/lib/phases/phase_local_mutation.ml
+++ b/engine/lib/phases/phase_local_mutation.ml
@@ -224,7 +224,7 @@ struct
             List.map ~f:darm arms
           in
           let typ =
-            match arms with [] -> B.TFalse | hd :: _ -> hd.arm.body.typ
+            match arms with [] -> UB.never_typ | hd :: _ -> hd.arm.body.typ
           in
           let scrutinee =
             dexpr_s { s with expr_level = []; drop_expr = false } scrutinee

--- a/engine/lib/phases/phase_reconstruct_for_loops.ml
+++ b/engine/lib/phases/phase_reconstruct_for_loops.ml
@@ -142,15 +142,30 @@ struct
                                                                 body =
                                                                   {
                                                                     e =
-                                                                      Break
+                                                                      App
                                                                         {
-                                                                          e =
+                                                                          f =
                                                                             {
                                                                               e =
                                                                                 GlobalVar
+                                                                                never_to_any;
+                                                                            };
+                                                                          args =
+                                                                            [
+                                                                              {
+                                                                                e =
+                                                                                Break
+                                                                                {
+                                                                                e =
+                                                                                {
+                                                                                e =
+                                                                                GlobalVar
                                                                                 (`TupleCons
                                                                                 0);
-                                                                            };
+                                                                                };
+                                                                                };
+                                                                              };
+                                                                            ];
                                                                         };
                                                                   };
                                                               };
@@ -217,7 +232,9 @@ struct
                && Concrete_ident.eq_name
                     Core__iter__traits__iterator__Iterator__next next_meth
                && Concrete_ident.eq_name Core__option__Option__None none_ctor
-               && Concrete_ident.eq_name Core__option__Option__Some some_ctor ->
+               && Concrete_ident.eq_name Core__option__Option__Some some_ctor
+               && Global_ident.eq_name Rust_primitives__hax__never_to_any
+                    never_to_any ->
             Some { it; pat; body; state; label; witness }
         | _ -> None
                [@ocamlformat "disable"]

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -150,7 +150,6 @@ module Raw = struct
     | TSlice { ty; _ } -> !"[" & pty span ty & !"]"
     | TRawPointer _ -> !"raw_pointer!()"
     | TRef { typ; mut; _ } -> !"&" & dmutability span mut & pty span typ
-    | TFalse -> !"!"
     | TParam i -> plocal_ident span i
     | TArrow (inputs, output) ->
         let arrow =

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -38,7 +38,6 @@ struct
             mut = dmutability span S.mutable_reference mut;
             region;
           }
-    | TFalse -> TFalse
     | TParam local_ident -> TParam local_ident
     | TArrow (inputs, output) ->
         TArrow (List.map ~f:(dty span) inputs, dty span output)

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -72,6 +72,10 @@ name = "naming"
 version = "0.1.0"
 
 [[package]]
+name = "never-type"
+version = "0.1.0"
+
+[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,5 +15,6 @@ members = [
         "loops",
         "even",
         "odd",
+        "never-type",
 ]
 resolver = "2"

--- a/tests/never-type/Cargo.toml
+++ b/tests/never-type/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "never-type"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.hax-tests]
+into."fstar" = { snapshot = "none" }

--- a/tests/never-type/src/lib.rs
+++ b/tests/never-type/src/lib.rs
@@ -13,3 +13,7 @@ fn test(b: bool) -> u8 {
     };
     3
 }
+
+fn any<T>() -> T {
+    panic!()
+}

--- a/tests/never-type/src/lib.rs
+++ b/tests/never-type/src/lib.rs
@@ -1,0 +1,15 @@
+#![allow(dead_code)]
+#![feature(never_type)]
+
+enum False {}
+
+fn never(h: False) -> ! {
+    match h {}
+}
+
+fn test(b: bool) -> u8 {
+    if b {
+        panic!();
+    };
+    3
+}


### PR DESCRIPTION
With the never type (noted `!` in Rust), it's possible to match against empty enums. The engine used to assume a match had at least one arm. Now, we pick the first arm not typed `!`, and resort to `!` if no such arm exists.

Status: this PR introduces some TFalse nodes, which are not supported by Coq, gotta fix that 