### PR TITLE
Improve setup and dependencies

### DIFF
--- a/engine/lib/concrete_ident/generate.sh
+++ b/engine/lib/concrete_ident/generate.sh
@@ -21,7 +21,7 @@ for json in $(
                     | sort -u
                ); do
     name=$(
-        echo "$json" | base64 --decode \
+        echo -n "$json" | base64 --decode \
             | jq '(.krate | ((.[0:1] | ascii_upcase) + .[1:])) + "__" + (.path | map((.data | if type == "object" then to_entries | first | .value else . end) + (.disambiguator | if . == 0 then "" else "_" + (. | tostring) end)) | join("__"))' -r
         )
     if [[ "$name" == *"dummy_hax_concrete_ident_wrapper"* ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-set -x -e
+set -eu
 
+# Ensures a given binary is available in PATH
 ensure_binary_available() {
     command -v "$1" >/dev/null 2>&1 || {
         printf '\e[31mError: binary \e[1m%s\e[0m\e[31m was not found.\e[0m\n' "$1"
@@ -10,14 +11,33 @@ ensure_binary_available() {
     }
 }
 
+# Installs the Rust CLI & frontend, providing `cargo-hax` and `driver-hax`
+install_rust_binaries() {
+    for i in driver subcommands; do
+        ( set -x; cargo install --force --path "cli/$i")
+    done
+}
+
+# Provides the `hax-engine` binary
+install_ocaml_engine() {
+    # Fixes out of memory issues (https://github.com/hacspec/hacspec-v2/issues/197)
+    {
+        # Limit the number of thread spawned by opam
+        export OPAMJOBS=2
+        # Make the garbadge collector of OCaml more agressive (see
+        # https://discuss.ocaml.org/t/how-to-limit-the-amount-of-memory-the-ocaml-compiler-is-allowed-to-use/797)
+        export OCAMLRUNPARAM="o=20"
+    }
+    # Make opam show logs when an error occurs
+    export OPAMERRLOGLEN=0
+    # Make opam ignore system dependencies (it doesn't handle properly certain situations)
+    export OPAMASSUMEDEPEXTS=1
+    (set -x; opam install --yes ./engine)
+}
+
 for binary in opam node rustup jq; do
     ensure_binary_available $binary
 done
+install_rust_binaries
+install_ocaml_engine
 
-# Install the Rust CLI & frontend, providing `cargo-hax` and `driver-hax`:
-for i in driver subcommands; do
-    cargo install --force --path "cli/$i";
-done
-
-# Install the OCaml engine:
-OPAMASSUMEDEPEXTS=1 opam install --yes ./engine

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,18 @@
 
 set -x -e
 
+ensure_binary_available() {
+    command -v "$1" >/dev/null 2>&1 || {
+        printf '\e[31mError: binary \e[1m%s\e[0m\e[31m was not found.\e[0m\n' "$1"
+        printf '\e[37m(Did you look at \e[1mManual installation\e[0m\e[37m in \e[1mREADME.md\e[0m\e[37m?)\e[0m.\n'
+        exit 1
+    }
+}
+
+for binary in opam node rustup jq; do
+    ensure_binary_available $binary
+done
+
 # Install the Rust CLI & frontend, providing `cargo-hax` and `driver-hax`:
 for i in driver subcommands; do
     cargo install --force --path "cli/$i";


### PR DESCRIPTION
This PR:
 - refactors `setup.sh`;
 - adds checks for system dependencies (currently: node, rustup, opam, jq);
 - adds env var `OPAMERRLOGLEN` so that `opam` display error logs when an error occurs (otherwise users are facing useless error messages, for them as well as for us);
 - adds env var `OCAMLRUNPARAM` and `OPAMJOBS` to limit the amount of memory used, fixing #197.

Note regarding #197: other people are facing high memory consumption while compiling OCaml stuff, see https://discuss.ocaml.org/t/how-to-limit-the-amount-of-memory-the-ocaml-compiler-is-allowed-to-use/797/2.
