### PR TITLE
Engine: reflect attributes on items

### DIFF
--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -116,13 +116,18 @@ struct
         bindings = r.bindings;
       }
 
-    let dgeneric_param (span : span) (p : A.generic_param) :
+    let dgeneric_param (span : span)
+        ({ ident; kind; attrs; span } : A.generic_param) :
         B.generic_param option =
-      match p with
-      | GPLifetime _ -> None
-      | GPType { ident; default } ->
-          Some (GPType { ident; default = Option.map ~f:(dty span) default })
-      | GPConst { ident; typ } -> Some (GPConst { ident; typ = dty span typ })
+      let ( let* ) x f = Option.bind ~f x in
+      let* kind =
+        match kind with
+        | GPLifetime _ -> None
+        | GPType { default } ->
+            Some (B.GPType { default = Option.map ~f:(dty span) default })
+        | GPConst { typ } -> Some (B.GPConst { typ = dty span typ })
+      in
+      Some B.{ ident; kind; attrs; span }
 
     let dgeneric_constraint (span : span) (p : A.generic_constraint) :
         B.generic_constraint option =

--- a/engine/lib/utils.ml
+++ b/engine/lib/utils.ml
@@ -9,6 +9,9 @@ let ( *** ) (f : 'a -> 'b) (g : 'c -> 'd) ((l, r) : 'a * 'c) : 'b * 'd =
 
 let map_fst f = f *** Fn.id
 let map_snd g = Fn.id *** g
+let map_fst3 f (x, y, z) = (f x, y, z)
+let map_snd3 f (x, y, z) = (x, f y, z)
+let map_thd3 f (x, y, z) = (x, y, f z)
 let fst3 (x, _, _) = x
 let snd3 (_, y, _) = y
 let thd3 (_, _, z) = z

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -2113,7 +2113,7 @@ pub struct GenericParam<Body: IsBody> {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::ImplItem<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::ImplItem<'tcx>, state: S as s)]
 pub struct ImplItem<Body: IsBody> {
     pub ident: Ident,
     pub owner_id: DefId,
@@ -2122,6 +2122,12 @@ pub struct ImplItem<Body: IsBody> {
     pub defaultness: Defaultness,
     pub span: Span,
     pub vis_span: Span,
+    #[map({
+        let tcx = s.base().tcx;
+        tcx.hir().attrs(rustc_hir::hir_id::HirId::from(owner_id.clone())).sinto(s)
+    })]
+    #[not_in_source]
+    pub attributes: Vec<Attribute>,
 }
 
 #[derive(AdtInto)]
@@ -2373,7 +2379,7 @@ pub enum TraitItemKind<Body: IsBody> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::TraitItem<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::TraitItem<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct TraitItem<Body: IsBody> {
     pub ident: Ident,
@@ -2382,6 +2388,12 @@ pub struct TraitItem<Body: IsBody> {
     pub kind: TraitItemKind<Body>,
     pub span: Span,
     pub defaultness: Defaultness,
+    #[map({
+        let tcx = s.base().tcx;
+        tcx.hir().attrs(rustc_hir::hir_id::HirId::from(owner_id.clone())).sinto(s)
+    })]
+    #[not_in_source]
+    pub attributes: Vec<Attribute>,
 }
 
 impl<'tcx, S: BaseState<'tcx> + HasOwnerId, Body: IsBody> SInto<S, EnumDef<Body>>

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -12,6 +12,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "attributes"
+version = "0.1.0"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,5 +16,6 @@ members = [
         "even",
         "odd",
         "never-type",
+        "attributes",
 ]
 resolver = "2"

--- a/tests/attributes/Cargo.toml
+++ b/tests/attributes/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "attributes"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.hax-tests]
+into."fstar" = { snapshot = "none" }

--- a/tests/attributes/README.md
+++ b/tests/attributes/README.md
@@ -1,0 +1,4 @@
+This example is more interesting with the debug mode enabled, to see all the attributes:
+ - `cargo hax into --debug-engine SOME_EMPTY_EXISTING_DIR fstar`
+ - `cd engine/utils/phase_debug_webapp && PORT=8989 node server.js SOME_EMPTY_EXISTING_DIR`
+ - browse `http://localhost:8989/`, and observe the attributes

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -1,0 +1,47 @@
+#![allow(dead_code)]
+#![feature(register_tool)]
+#![register_tool(hax)]
+
+/** TypeAlias:BlockDocComment Lorem ipsum dolor sit amet, consectetur
+adipiscing elit. Integer bibendum, massa quis facilisis aliquam,
+dui libero auctor sem, aliquet dignissim urna magna ac turpis. */
+#[hax::a::path(TypeAlias attr)]
+type TypeAlias<#[hax::a::path(TypeAlias:T attr)] T: Clone> = (T, u8);
+
+/// f:LineBlockComment
+#[hax::a::path(f attr)]
+fn f<#[hax::a::path(f:T attr)] T, #[hax::a::path(f:Y attr)] const Y: usize>(_x: T) -> usize {
+    Y
+}
+
+#[hax::a::path(Foo attr)]
+enum Foo {
+    #[hax::a::path(Foo:A attr)]
+    A(
+        #[hax::a::path(Foo:A:u8 attr)] u8,
+        #[hax::a::path(Foo:A:u16 attr)] u16,
+    ),
+    #[hax::a::path(Foo:B attr)]
+    B {
+        /// some Foo::B::x comment
+        #[hax::a::path(Foo:B:x attr)]
+        x: u8,
+        /// some Foo::B::y comment
+        #[hax::a::path(Foo:B:y attr)]
+        y: u16,
+    },
+}
+
+#[hax::a::path(Bar attr)]
+struct Bar {
+    #[hax::a::path(Bar:field1 attr)]
+    field1: u64,
+    /** some Bar::field2 comment Quisque et purus lacinia, venenatis
+       risus eu, hendrerit arcu. Nunc posuere iaculis mattis. Sed at
+       enim justo. Praesent aliquet ipsum in enim mollis
+       faucibus. Morbi eu diam molestie, posuere quam eget, pulvinar
+       diam.
+    */
+    #[hax::a::path(Bar:field2 attr)]
+    field2: u32,
+}


### PR DESCRIPTION
This PR:
 - transports all the Rust item attributes;
 - improve the debug Rust printer (it now prints those attributes, and also enum/structs).

The attributes can be on:
 - generic parameters;
 - function parameters;
 - variants;
 - variant fields;
 - items themselves.
