### PR TITLE
Exporter: misc. improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "hax-frontend-exporter-options",
  "hax-lint",
  "inquire",
+ "itertools 0.11.0",
  "serde",
  "serde_json",
  "tracing",

--- a/cli/driver/Cargo.toml
+++ b/cli/driver/Cargo.toml
@@ -20,6 +20,7 @@ hax-cli-options-engine.workspace = true
 hax-frontend-exporter-options.workspace = true
 hax-lint.workspace = true
 hax-diagnostics.workspace = true
+itertools.workspace = true
 which.workspace = true
 inquire = "0.6"
 const_format = "0.2"

--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -86,7 +86,7 @@ pub(crate) fn scalar_int_to_lit_kind<'tcx, S: BaseState<'tcx>>(
     use rustc_middle::ty;
     match ty.kind() {
         ty::Char => LitKind::Char(
-            x.try_to_u8()
+            char::try_from(x)
                 .expect("scalar_int_to_lit_kind: expected a char")
                 .into(),
         ),

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -276,7 +276,6 @@ pub(crate) fn attribute_from_scope<'tcx, S: ExprState<'tcx>>(
 
 use itertools::Itertools;
 
-#[tracing::instrument(skip(s))]
 pub fn inline_macro_invocations<'t, S: BaseState<'t>, Body: IsBody>(
     ids: impl Iterator<Item = rustc_hir::ItemId>,
     s: &S,

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -278,7 +278,7 @@ use itertools::Itertools;
 
 #[tracing::instrument(skip(s))]
 pub fn inline_macro_invocations<'t, S: BaseState<'t>, Body: IsBody>(
-    ids: &Vec<rustc_hir::ItemId>,
+    ids: impl Iterator<Item = rustc_hir::ItemId>,
     s: &S,
 ) -> Vec<Item<Body>> {
     let tcx: rustc_middle::ty::TyCtxt = s.base().tcx;
@@ -291,9 +291,7 @@ pub fn inline_macro_invocations<'t, S: BaseState<'t>, Body: IsBody>(
         }
     }
 
-    ids.iter()
-        .cloned()
-        .map(|id| tcx.hir().item(id))
+    ids.map(|id| tcx.hir().item(id))
         .group_by(|item| SpanEq(raw_macro_invocation_of_span(item.span, s)))
         .into_iter()
         .map(|(mac, items)| match mac.0 {

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -2415,7 +2415,7 @@ impl<'a, S: BaseState<'a> + HasOwnerId, Body: IsBody> SInto<S, TraitItem<Body>>
 
 impl<'a, 'tcx, S: BaseState<'tcx>, Body: IsBody> SInto<S, Vec<Item<Body>>> for rustc_hir::Mod<'a> {
     fn sinto(&self, s: &S) -> Vec<Item<Body>> {
-        inline_macro_invocations(&self.item_ids.iter().cloned().collect(), s)
+        inline_macro_invocations(self.item_ids.iter().copied(), s)
         // .iter()
         // .map(|item_id| item_id.sinto(s))
         // .collect()

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -2605,20 +2605,7 @@ impl<'tcx, S: BaseState<'tcx> + HasOwnerId> SInto<S, GenericBounds>
         };
         predicates
             .iter()
-            .map(|(pred, span)| {
-                let pred: rustc_middle::ty::Predicate = pred.clone();
-                let kind: rustc_middle::ty::Binder<'_, rustc_middle::ty::PredicateKind> =
-                    pred.kind();
-                let kind: rustc_middle::ty::PredicateKind =
-                    kind.no_bound_vars().unwrap_or_else(|| {
-                        tcx.sess.span_err(
-                            span.clone(),
-                            format!("[GenericBounds]: [no_bound_vars] failed"),
-                        );
-                        rustc_middle::ty::PredicateKind::Ambiguous
-                    });
-                kind.sinto(s)
-            })
+            .map(|(pred, _span)| tcx.erase_late_bound_regions(pred.clone().kind()).sinto(s))
             .collect()
     }
 }


### PR DESCRIPTION
This PR fixes a few things:
 - more `steal`ing issues (but not all, I found some, one in `Core`, notably);
 - misc. bugs with char consts, opaque types and generic bounds;
 - we now translate correctly `PhantomData`s.

Those fixes are for bugs I stumbled upon while looking at big crate (`Core`, but not only), thus that's generally pretty hard to minimize. (that's why this PR doesn't ship unit tests)