### PR TITLE
CLI: allow for including/excluding items from the translation

### DIFF
--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -28,7 +28,8 @@ let run () : Types.output =
       |> List.concat_map ~f:(fun item ->
              try
                Result.map_error ~f:Import_thir.show_error
-                 (Import_thir.c_item item)
+                 (Import_thir.c_item
+                    options.backend.translation_options.include_namespaces item)
                |> Result.ok_or_failwith
              with Failure e -> failwith e)
     in

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -284,8 +284,6 @@ end
 let matches_namespace (ns : Types.namespace) (did : t) : bool =
   let did = did.def_id in
   let path : string option list =
-    (* Some did.krate *)
-    (* :: *)
     did.path
     |> List.map ~f:(fun (x : Imported.disambiguated_def_path_item) ->
            View.Utils.string_of_def_path_item x.data)

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -281,5 +281,28 @@ module DefaultNamePolicy = struct
   let index_field_transform = Fn.id
 end
 
+let matches_namespace (ns : Types.namespace) (did : t) : bool =
+  let did = did.def_id in
+  let path : string option list =
+    (* Some did.krate *)
+    (* :: *)
+    did.path
+    |> List.map ~f:(fun (x : Imported.disambiguated_def_path_item) ->
+           View.Utils.string_of_def_path_item x.data)
+  in
+  let rec aux (pattern : Types.namespace_chunk list) (path : string option list)
+      =
+    match (pattern, path) with
+    | [], [] -> true
+    | Exact x :: pattern, Some y :: path ->
+        [%equal: string] x y && aux pattern path
+    | Glob One :: pattern, _ :: path -> aux pattern path
+    | Glob Many :: pattern, [] -> aux pattern []
+    | Glob Many :: pattern', _ :: path' ->
+        aux pattern' path || aux pattern path'
+    | _ -> false
+  in
+  aux ns.chunks path
+
 module DefaultViewAPI = MakeViewAPI (DefaultNamePolicy)
 include DefaultViewAPI

--- a/engine/lib/concrete_ident/concrete_ident.mli
+++ b/engine/lib/concrete_ident/concrete_ident.mli
@@ -22,6 +22,7 @@ val to_debug_string : t -> string
 type view = { crate : string; path : string list; definition : string }
 
 val map_path_strings : f:(string -> string) -> t -> t
+val matches_namespace: Types.namespace -> t -> bool
 
 include module type of struct
   include Concrete_ident_sig.Make (struct

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -66,24 +66,13 @@ module type MakeT = sig
 end
 
 module Make (Opts : OPTS) : MakeT = struct
-  let included_inclusion_clauses' (def_id : Concrete_ident.t) :
+  let included_inclusion_clauses (def_id : Concrete_ident.t) :
       Types.inclusion_kind =
     Opts.inclusion_clauses |> List.rev
     |> List.find ~f:(fun clause ->
            Concrete_ident.matches_namespace clause.Types.namespace def_id)
-    |> (fun x ->
-         prerr_endline @@ "GOT: " ^ [%show: Types.inclusion_clause option] x;
-         x)
     |> Option.map ~f:(fun (clause : Types.inclusion_clause) -> clause.kind)
     |> Option.value ~default:(Included : Types.inclusion_kind)
-
-  let included_inclusion_clauses (def_id : Concrete_ident.t) =
-    let r = included_inclusion_clauses' def_id in
-    prerr_endline @@ "included_inclusion_clauses("
-    ^ [%show: Concrete_ident.t] def_id
-    ^ ") = "
-    ^ [%show: Types.inclusion_kind] r;
-    r
 
   let def_id kind (def_id : Thir.def_id) : global_ident =
     `Concrete (Concrete_ident.of_def_id kind def_id)

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1310,9 +1310,7 @@ end
 let c_item inclusion_clauses (item : Thir.item) : (item list, error) Result.t =
   let (module M) =
     (module Make (struct
-      let inclusion_clauses =
-        prerr_endline @@ [%show: Types.inclusion_clause list] inclusion_clauses;
-        inclusion_clauses
+      let inclusion_clauses = inclusion_clauses
     end) : MakeT)
   in
   M.c_item item |> Result.return

--- a/engine/lib/import_thir.mli
+++ b/engine/lib/import_thir.mli
@@ -10,5 +10,6 @@ type error =
 [@@deriving show]
 
 val c_item :
+  Types.inclusion_clause list ->
   Types.item_for__decorated_for__expr_kind ->
   (Ast.Rust.item list, error) Result.t


### PR DESCRIPTION
Consider the following crate:
```rust
fn f() {}
mod hello {
  fn g() {}
  const _: () = {
   fn h() {}
   fn i() {}
  }
}
fn j() {}
```
This PR allows for things like: `cargo hax into -i '-** +f +hello::** -hello::*::h'`, which results in extracting `f`, `g`, `i`, but not `h` or `j`.