### PR TITLE
Misc PR: core extraction features, traits, generic improvements...

### DIFF
--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -29,6 +29,8 @@ jobs:
     - if: runner.os == 'macOS'
       run: brew install opam nodejs rustup-init jq
     - if: runner.os == 'Linux'
+      run: sudo apt-get update
+    - if: runner.os == 'Linux'
       run: sudo apt-get install -y opam nodejs jq
     - run: curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
     - run: opam init --bare -y && opam switch create -y 4.14.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ext-trait"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5"
+dependencies = [
+ "ext-trait-proc_macros",
+]
+
+[[package]]
+name = "ext-trait-proc_macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "extension-traits"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537"
+dependencies = [
+ "ext-trait",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +478,7 @@ name = "hax-frontend-exporter"
 version = "0.1.0"
 dependencies = [
  "adt-into",
+ "extension-traits",
  "hax-frontend-exporter-options",
  "itertools 0.11.0",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "extension-traits",
  "hax-frontend-exporter-options",
  "itertools 0.11.0",
+ "lazy_static",
  "paste",
  "schemars",
  "serde",

--- a/cli/driver/src/exporter.rs
+++ b/cli/driver/src/exporter.rs
@@ -382,12 +382,16 @@ impl Callbacks for ExtractionCallbacks {
                     }
                 }
                 ExporterCommand::Backend(backend) => {
-                    let (spans, _def_ids, _impl_infos, converted_items) =
+                    let (spans, _def_ids, impl_infos, converted_items) =
                         convert_thir(&self.clone().into(), self.macro_calls.clone(), tcx);
 
                     let engine_options = hax_cli_options_engine::EngineOptions {
                         backend: backend.clone(),
                         input: converted_items,
+                        impl_infos: impl_infos
+                            .iter()
+                            .map(|(k, (t, p))| (k.clone(), (t.clone(), p.clone())))
+                            .collect(),
                     };
                     let mut engine_subprocess = find_hax_engine()
                         .stdin(std::process::Stdio::piped())
@@ -404,7 +408,7 @@ impl Callbacks for ExtractionCallbacks {
                         })
                         .unwrap();
 
-                    serde_json::to_writer(
+                    serde_json::to_writer::<_, hax_cli_options_engine::EngineOptions>(
                         std::io::BufWriter::new(
                             engine_subprocess
                                 .stdin

--- a/cli/driver/src/exporter.rs
+++ b/cli/driver/src/exporter.rs
@@ -163,6 +163,13 @@ fn convert_thir<'tcx, Body: hax_frontend_exporter::IsBody>(
 ) -> (
     Vec<rustc_span::Span>,
     Vec<hax_frontend_exporter::DefId>,
+    std::collections::HashMap<
+        hax_frontend_exporter::DefId,
+        (
+            hax_frontend_exporter::Ty,
+            Vec<hax_frontend_exporter::Predicate>,
+        ),
+    >,
     Vec<hax_frontend_exporter::Item<Body>>,
 ) {
     let mut state = hax_frontend_exporter::state::State::new(tcx, options.clone());
@@ -170,6 +177,7 @@ fn convert_thir<'tcx, Body: hax_frontend_exporter::IsBody>(
     state.base.cached_thirs = Rc::new(precompute_local_thir_bodies(tcx));
 
     let result = hax_frontend_exporter::inline_macro_invocations(tcx.hir().items(), &state);
+    let impl_infos = hax_frontend_exporter::impl_def_ids_to_impled_types_and_bounds(&state);
     let exported_spans = state.base.exported_spans.borrow().clone();
 
     let exported_def_ids = {
@@ -180,6 +188,7 @@ fn convert_thir<'tcx, Body: hax_frontend_exporter::IsBody>(
     (
         exported_spans.into_iter().collect(),
         exported_def_ids,
+        impl_infos,
         result,
     )
 }
@@ -300,7 +309,7 @@ impl Callbacks for ExtractionCallbacks {
                 ExporterCommand::JSON {
                     output_file,
                     mut kind,
-                    include_def_ids,
+                    include_extra,
                 } => {
                     struct Driver<'tcx> {
                         options: hax_frontend_exporter_options::Options,
@@ -308,22 +317,26 @@ impl Callbacks for ExtractionCallbacks {
                             HashMap<hax_frontend_exporter::Span, hax_frontend_exporter::Span>,
                         tcx: TyCtxt<'tcx>,
                         output_file: PathOrDash,
-                        include_def_ids: bool,
+                        include_extra: bool,
                     }
                     impl<'tcx> Driver<'tcx> {
                         fn to_json<Body: hax_frontend_exporter::IsBody + Serialize>(self) {
-                            let (_, def_ids, converted_items) = convert_thir::<Body>(
+                            let (_, def_ids, impl_infos, converted_items) = convert_thir::<Body>(
                                 &self.options,
                                 self.macro_calls.clone(),
                                 self.tcx,
                             );
 
                             let dest = self.output_file.open_or_stdout();
-                            (if self.include_def_ids {
+                            (if self.include_extra {
                                 serde_json::to_writer(
                                     dest,
                                     &hax_cli_options_engine::WithDefIds {
                                         def_ids,
+                                        impl_infos: impl_infos
+                                            .iter()
+                                            .map(|(k, (t, p))| (k.clone(), (t.clone(), p.clone())))
+                                            .collect(),
                                         items: converted_items,
                                     },
                                 )
@@ -338,7 +351,7 @@ impl Callbacks for ExtractionCallbacks {
                         macro_calls: self.macro_calls.clone(),
                         tcx,
                         output_file,
-                        include_def_ids,
+                        include_extra,
                     };
                     mod from {
                         pub use hax_cli_options::ExportBodyKind::{
@@ -369,7 +382,7 @@ impl Callbacks for ExtractionCallbacks {
                     }
                 }
                 ExporterCommand::Backend(backend) => {
-                    let (spans, _def_ids, converted_items) =
+                    let (spans, _def_ids, _impl_infos, converted_items) =
                         convert_thir(&self.clone().into(), self.macro_calls.clone(), tcx);
 
                     let engine_options = hax_cli_options_engine::EngineOptions {

--- a/cli/options/engine/src/lib.rs
+++ b/cli/options/engine/src/lib.rs
@@ -28,5 +28,12 @@ pub struct Output {
 #[derive(JsonSchema, Debug, Clone, Serialize, Deserialize)]
 pub struct WithDefIds<Body: hax_frontend_exporter::IsBody> {
     pub def_ids: Vec<hax_frontend_exporter::DefId>,
+    pub impl_infos: Vec<(
+        hax_frontend_exporter::DefId,
+        (
+            hax_frontend_exporter::Ty,
+            Vec<hax_frontend_exporter::Predicate>,
+        ),
+    )>,
     pub items: Vec<hax_frontend_exporter::Item<Body>>,
 }

--- a/cli/options/engine/src/lib.rs
+++ b/cli/options/engine/src/lib.rs
@@ -8,6 +8,13 @@ type ThirBody = hax_frontend_exporter::ThirBody;
 pub struct EngineOptions {
     pub backend: BackendOptions,
     pub input: Vec<hax_frontend_exporter::Item<ThirBody>>,
+    pub impl_infos: Vec<(
+        hax_frontend_exporter::DefId,
+        (
+            hax_frontend_exporter::Ty,
+            Vec<hax_frontend_exporter::Predicate>,
+        ),
+    )>,
 }
 
 #[derive(JsonSchema, Debug, Clone, Serialize, Deserialize)]

--- a/cli/options/src/lib.rs
+++ b/cli/options/src/lib.rs
@@ -17,8 +17,8 @@ impl std::default::Default for ForceCargoBuild {
     }
 }
 
-impl std::convert::From<&std::ffi::OsStr> for ForceCargoBuild {
-    fn from(s: &std::ffi::OsStr) -> Self {
+impl std::convert::From<&str> for ForceCargoBuild {
+    fn from(s: &str) -> Self {
         use std::time::{SystemTime, UNIX_EPOCH};
         if s == "false" {
             ForceCargoBuild {
@@ -39,12 +39,11 @@ pub enum PathOrDash {
     Path(PathBuf),
 }
 
-impl std::convert::From<&std::ffi::OsStr> for PathOrDash {
-    fn from(s: &std::ffi::OsStr) -> Self {
-        if s == "-" {
-            PathOrDash::Dash
-        } else {
-            PathOrDash::Path(PathBuf::from(s))
+impl std::convert::From<&str> for PathOrDash {
+    fn from(s: &str) -> Self {
+        match s {
+            "-" => PathOrDash::Dash,
+            _ => PathOrDash::Path(PathBuf::from(s)),
         }
     }
 }

--- a/cli/options/src/lib.rs
+++ b/cli/options/src/lib.rs
@@ -241,7 +241,7 @@ pub enum ExporterCommand {
             default_value = "hax_frontend_export.json"
         )]
         output_file: PathOrDash,
-        /// Wether the bodies are exported as THIR, built MIR, const
+        /// Whether the bodies are exported as THIR, built MIR, const
         /// MIR, or a combination. Repeat this option to extract a
         /// combination (e.g. [-k thir -k mir-built]).
         #[arg(
@@ -253,7 +253,7 @@ pub enum ExporterCommand {
         )]
         kind: Vec<ExportBodyKind>,
 
-        /// Wether to include extra informations about `DefId`s.
+        /// Whether to include extra informations about `DefId`s.
         #[arg(short = 'E', long = "include-extra", default_value = "false")]
         include_extra: bool,
     },

--- a/cli/options/src/lib.rs
+++ b/cli/options/src/lib.rs
@@ -221,9 +221,9 @@ pub enum ExporterCommand {
         )]
         kind: Vec<ExportBodyKind>,
 
-        /// Wether to include the list of def_id exported.
-        #[arg(short = 'D', long = "def-ids", default_value = "false")]
-        include_def_ids: bool,
+        /// Wether to include extra informations about `DefId`s.
+        #[arg(short = 'E', long = "include-extra", default_value = "false")]
+        include_extra: bool,
     },
 }
 

--- a/engine/backends/coq/coq/coq_backend.ml
+++ b/engine/backends/coq/coq/coq_backend.ml
@@ -528,6 +528,7 @@ struct
         if is_external then [] else [ C.AST.Require (path, rename) ]
     | HaxError s -> [ __TODO_item__ span s ]
     | NotImplementedYet -> [ __TODO_item__ span "Not implemented yet?" ]
+    | Alias _ -> [ __TODO_item__ span "Not implemented yet? alias" ]
     | Trait { name; generics; items } ->
         [
           C.AST.Class

--- a/engine/backends/coq/coq/coq_backend.ml
+++ b/engine/backends/coq/coq/coq_backend.ml
@@ -181,10 +181,8 @@ struct
         C.AST.ArrayTy (pty span typ, "TODO: Int.to_string length")
     | TSlice { ty; _ } -> C.AST.SliceTy (pty span ty)
     | TParam i -> C.AST.Name i.name
-    | TProjectedAssociatedType s ->
-        C.AST.Wild
-        (* __TODO_ty__ span ("proj:assoc:type" ^ s) *)
-        (* failwith "proj:assoc:type" *)
+    | TAssociatedType s -> C.AST.Wild
+    | TOpaque _ -> __TODO_ty__ span "pty: TAssociatedType/TOpaque"
     | _ -> .
 
   and args_ty span (args : generic_value list) : C.AST.ty list =

--- a/engine/backends/easycrypt/easycrypt_backend.ml
+++ b/engine/backends/easycrypt/easycrypt_backend.ml
@@ -139,6 +139,7 @@ let translate' (bo : BackendOptions.t) (items : AST.item list) : Types.file list
              | HaxError _ -> ()
              | IMacroInvokation mi -> ()
              | Use _ -> ()
+             | Alias _ -> ()
              | NotImplementedYet -> ())
     in
 

--- a/engine/backends/easycrypt/easycrypt_backend.ml
+++ b/engine/backends/easycrypt/easycrypt_backend.ml
@@ -182,7 +182,8 @@ let translate' (bo : BackendOptions.t) (items : AST.item list) : Types.file list
     | TRef _ -> assert false
     | TParam _ -> assert false
     | TArrow (_, _) -> assert false
-    | TProjectedAssociatedType _ -> assert false
+    | TAssociatedType _ -> assert false
+    | TOpaque _ -> assert false
   and doit_type_arg (fmt : Format.formatter) (tyarg : generic_value) =
     match tyarg with GType ty -> doit_type fmt ty | _ -> assert false
   and doit_stmt (fmt : Format.formatter) (expr : expr) =

--- a/engine/backends/fstar/fstar_ast.ml
+++ b/engine/backends/fstar/fstar_ast.ml
@@ -19,6 +19,7 @@ let lid path =
 
 let lid_of_id id = Ident.lid_of_ids [ id ]
 let term (tm : AST.term') = AST.{ tm; range = dummyRange; level = Expr }
+let generate_fresh_ident () = Ident.gen dummyRange
 
 let decl ?(quals = []) (d : AST.decl') =
   `Item AST.{ d; drange = dummyRange; quals = []; attrs = [] }

--- a/engine/backends/fstar/fstar_ast.ml
+++ b/engine/backends/fstar/fstar_ast.ml
@@ -27,6 +27,10 @@ let decl ?(quals = []) (d : AST.decl') =
 let decls ?(quals = []) x = [ decl ~quals x ]
 let pat (pat : AST.pattern') = AST.{ pat; prange = dummyRange }
 
+module Attrs = struct
+  let no_method = term @@ AST.Var FStar_Parser_Const.no_method_lid
+end
+
 let pat_var_tcresolve (var : string option) =
   let tcresolve =
     Some (AST.Meta (term @@ AST.Var FStar_Parser_Const.tcresolve_lid))
@@ -46,9 +50,10 @@ let mk_e_abs args body =
 let mk_e_app base args =
   AST.mkApp base (List.map ~f:(fun arg -> (arg, AST.Nothing)) args) dummyRange
 
-let mk_e_binder b =
-  AST.{ b; brange = dummyRange; blevel = Un; aqual = None; battributes = [] }
+let mk_binder ?aqual b =
+  AST.{ b; brange = dummyRange; blevel = Un; aqual; battributes = [] }
 
+let mk_e_binder b = mk_binder b
 let term_of_lid path = term @@ AST.Name (lid path)
 let binder_of_term (t : AST.term) : AST.binder = mk_e_binder @@ AST.NoName t
 let unit = term AST.(Const Const_unit)

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -967,6 +967,7 @@ let translate (bo : BackendOptions.t) (items : AST.item list) : Types.file list
            })
 
 open Phase_utils
+module DepGraph = Dependencies.Make (InputLanguage)
 
 module TransformToInputLanguage =
   [%functor_application
@@ -993,5 +994,9 @@ module TransformToInputLanguage =
 
 let apply_phases (bo : BackendOptions.t) (items : Ast.Rust.item list) :
     AST.item list =
-  TransformToInputLanguage.ditems items
-  |> List.map ~f:U.Mappers.add_typ_ascription
+  let items =
+    TransformToInputLanguage.ditems items
+    |> List.map ~f:U.Mappers.add_typ_ascription
+    |> DepGraph.name_me
+  in
+  items

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -924,9 +924,10 @@ struct
         let d = F.AST.Tycon (false, true, [ tcdef ]) in
         [ `Item { d; drange = F.dummyRange; quals = []; attrs = [] } ]
     | Impl { generics; self_ty = _; of_trait = trait, generic_args; items } ->
-        (* this unique name is stupid, we have disambiguators... And things will be refered differently! very stupid, TODO *)
-        let unique_name_todo = "impl_" ^ Int.to_string ([%hash: item] e) in
-        let pat = F.pat @@ F.AST.PatVar (F.id unique_name_todo, None, []) in
+        let pat =
+          let name = U.Concrete_ident_view.to_definition_name e.ident in
+          F.pat @@ F.AST.PatVar (F.id name, None, [])
+        in
         let pat =
           F.pat
           @@ F.AST.PatApp

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -235,6 +235,8 @@ struct
       (c Core__cmp__PartialEq__ne, (2, "<>."));
       (c Core__cmp__PartialOrd__ge, (2, ">=."));
       (c Core__cmp__PartialOrd__gt, (2, ">."));
+      (`Primitive (LogicalOp And), (2, "&&"));
+      (`Primitive (LogicalOp Or), (2, "||"));
     ]
     |> Map.of_alist_exn (module Global_ident)
 

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -536,7 +536,7 @@ struct
         b = F.AST.Annotated (F.generate_fresh_ident (), tc);
         brange = F.dummyRange;
         blevel = Un;
-        aqual = None;
+        aqual = Some TypeClassArg;
         battributes = [];
       }
 

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -227,8 +227,8 @@ struct
       (c Core__ops__arith__Mul__mul, (2, "*!"));
       (c Core__ops__arith__Div__div, (2, "/!"));
       (c Core__ops__arith__Rem__rem, (2, "%!"));
-      (c Core__ops__bit__Shl__shl, (2, ">>!"));
-      (c Core__ops__bit__Shr__shr, (2, "<<!"));
+      (c Core__ops__bit__Shl__shl, (2, "<<!"));
+      (c Core__ops__bit__Shr__shr, (2, ">>!"));
       (c Core__cmp__PartialEq__eq, (2, "=."));
       (c Core__cmp__PartialOrd__lt, (2, "<."));
       (c Core__cmp__PartialOrd__le, (2, "<=."));

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -87,7 +87,7 @@ module Context = struct
   type t = { current_namespace : string * string list; items : item list }
 end
 
-let magic_id_raw_local_ident = LocalIdent.var_id_of_int (-765142)
+let magic_id_raw_local_ident = LocalIdent.mk_id Expr (-765142)
 
 module Make (Ctx : sig
   val ctx : Context.t

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -949,7 +949,9 @@ struct
           else fields
         in
         let body = F.term @@ F.AST.Record (None, fields) in
-        F.decls @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, body) ])
+        let tcinst = F.term @@ F.AST.Var FStar_Parser_Const.tcinstance_lid in
+        F.decls ~quals:[ tcinst ]
+        @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, body) ])
     | HaxError details ->
         [
           `Comment

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -626,6 +626,16 @@ struct
   and pitem_unwrapped (e : item) :
       [> `Item of F.AST.decl | `Comment of string ] list =
     match e.v with
+    | Alias { name; item } ->
+        let pat =
+          F.pat
+          @@ F.AST.PatVar
+               (F.id @@ U.Concrete_ident_view.to_definition_name name, None, [])
+        in
+        F.decls ~quals:[ F.AST.Unfold_for_unification_and_vcgen ]
+        @@ F.AST.TopLevelLet
+             ( NoLetQualifier,
+               [ (pat, F.term @@ F.AST.Name (pconcrete_ident item)) ] )
     | Fn { name; generics; body; params } ->
         let pat =
           F.pat

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -189,10 +189,6 @@ struct
         | Some name -> "impl_" ^ Int.to_string ([%hash: string] name)
         | _ -> e.name)
 
-  let pgeneric_param_name (name : string) : string =
-    String.lowercase
-      name (* TODO: this is not robust, might produce name clashes *)
-
   let pfield_ident span (f : global_ident) : F.Ident.lident =
     match f with
     | `Concrete cid -> pconcrete_ident cid
@@ -270,11 +266,7 @@ struct
     | TFloat _ -> Error.unimplemented ~details:"pty: Float" span
     | TArray { typ; length } ->
         F.mk_e_app (F.term_of_lid [ "array" ]) [ pty span typ; pexpr length ]
-    | TParam i ->
-        F.term
-        @@ F.AST.Var
-             (F.lid_of_id
-             @@ plocal_ident { i with name = pgeneric_param_name i.name })
+    | TParam i -> F.term @@ F.AST.Var (F.lid_of_id @@ plocal_ident i)
     | TProjectedAssociatedType s -> F.term @@ F.AST.Wild
     | _ -> .
 
@@ -465,14 +457,10 @@ struct
 
   and parm { arm = { arm_pat; body } } = (ppat arm_pat, None, pexpr body)
 
-  let rec pgeneric_param span (p : generic_param) =
+  let rec pgeneric_param span (p : generic_param) : F.AST.pattern =
     let mk_implicit (ident : local_ident) ty =
       let v =
-        F.pat
-        @@ F.AST.PatVar
-             ( plocal_ident { ident with name = pgeneric_param_name ident.name },
-               Some F.AST.Implicit,
-               [] )
+        F.pat @@ F.AST.PatVar (plocal_ident ident, Some F.AST.Implicit, [])
       in
       F.pat @@ F.AST.PatAscribed (v, (ty, None))
     in
@@ -487,8 +475,7 @@ struct
 
   let rec pgeneric_constraint span (nth : int) (c : generic_constraint) =
     match c with
-    | GCLifetime _ ->
-        Error.assertion_failure span "pgeneric_constraint:LIFETIME"
+    | GCLifetime _ -> .
     | GCType { typ; implements } ->
         let implements : trait_ref = implements in
         let trait = F.term @@ F.AST.Name (pconcrete_ident implements.trait) in
@@ -501,16 +488,21 @@ struct
   let rec pgeneric_param_bd span (p : generic_param) =
     let ident = p.ident in
     match p.kind with
-    | GPLifetime _ -> Error.assertion_failure span "pgeneric_param_bd:LIFETIME"
-    | GPType { default = None } ->
+    | GPLifetime _ -> .
+    | GPType { default = _ } ->
         let t = F.term @@ F.AST.Name (F.lid [ "Type" ]) in
         F.mk_e_binder (F.AST.Annotated (plocal_ident ident, t))
     | GPType _ ->
         Error.unimplemented span ~details:"pgeneric_param_bd:Type with default"
     | GPConst { typ } ->
-        Error.unimplemented span ~details:"pgeneric_param_bd:const todo"
+        F.mk_e_binder (F.AST.Annotated (plocal_ident ident, pty span typ))
 
-  let rec pgeneric_constraint_bd span (c : generic_constraint) =
+  let pgeneric_param_ident span (p : generic_param) =
+    match (pgeneric_param_bd span p).b with
+    | Annotated (ident, _) -> ident
+    | _ -> failwith "pgeneric_param_ident"
+
+  let rec pgeneric_constraint_type span (c : generic_constraint) =
     match c with
     | GCLifetime _ ->
         Error.assertion_failure span "pgeneric_constraint_bd:LIFETIME"
@@ -518,15 +510,22 @@ struct
         let implements : trait_ref = implements in
         let trait = F.term @@ F.AST.Name (pconcrete_ident implements.trait) in
         let args = List.map ~f:(pgeneric_value span) implements.args in
-        let tc = F.mk_e_app trait (*pty typ::*) args in
-        F.AST.
-          {
-            b = F.AST.Annotated (F.generate_fresh_ident (), tc);
-            brange = F.dummyRange;
-            blevel = Un;
-            aqual = None;
-            battributes = [];
-          }
+        F.mk_e_app trait args
+
+  let rec pgeneric_constraint_bd span (c : generic_constraint) =
+    let tc = pgeneric_constraint_type span c in
+    F.AST.
+      {
+        b = F.AST.Annotated (F.generate_fresh_ident (), tc);
+        brange = F.dummyRange;
+        blevel = Un;
+        aqual = None;
+        battributes = [];
+      }
+
+  let pgenerics span generics =
+    List.map ~f:(pgeneric_param_bd span) generics.params
+    @ List.map ~f:(pgeneric_constraint_bd span) generics.constraints
 
   let get_attr (type a) (name : string) (map : string -> a) (attrs : attrs) :
       a option =
@@ -625,7 +624,14 @@ struct
   let rec pitem (e : item) : [> `Item of F.AST.decl | `Comment of string ] list
       =
     try pitem_unwrapped e
-    with Diagnostics.SpanFreeError.Exn _ -> [ `Comment "item error backend" ]
+    with Diagnostics.SpanFreeError.Exn error ->
+      let error = Diagnostics.SpanFreeError.payload error in
+      let error = [%show: Diagnostics.Context.t * Diagnostics.kind] error in
+      [
+        `Comment
+          ("item error backend: " ^ error ^ "\n\nLast AST:\n"
+          ^ (U.LiftToFullAst.item e |> Print_rust.pitem_str));
+      ]
 
   and pitem_unwrapped (e : item) :
       [> `Item of F.AST.decl | `Comment of string ] list =
@@ -698,8 +704,7 @@ struct
                [
                  F.AST.TyconRecord
                    ( F.id @@ U.Concrete_ident_view.to_definition_name name,
-                     [],
-                     (* todo type parameters & constraints *)
+                     pgenerics e.span generics,
                      None,
                      [],
                      List.map
@@ -719,8 +724,12 @@ struct
                ] )
     | Type { name; generics; variants; _ } ->
         let self =
-          F.term_of_lid [ U.Concrete_ident_view.to_definition_name name ]
+          F.mk_e_app
+            (F.term_of_lid [ U.Concrete_ident_view.to_definition_name name ])
+            (List.map ~f:(pgeneric_param_ident e.span) generics.params
+            |> List.map ~f:(fun id -> F.term @@ F.AST.Name (F.lid_of_id id)))
         in
+
         let constructors =
           List.map
             ~f:(fun { name; arguments; is_record; _ } ->
@@ -758,8 +767,7 @@ struct
                [
                  F.AST.TyconVariant
                    ( F.id @@ U.Concrete_ident_view.to_definition_name name,
-                     [],
-                     (* todo type parameters & constraints *)
+                     pgenerics e.span generics,
                      None,
                      constructors );
                ] )
@@ -835,40 +843,62 @@ struct
             | _ -> unsupported_macro ())
         | _ -> unsupported_macro ())
     | Trait { name; generics; items } ->
-        let bds =
-          List.map ~f:(pgeneric_param_bd e.span) generics.params
-          @ List.map ~f:(pgeneric_constraint_bd e.span) generics.constraints
-        in
-        let name = F.id @@ U.Concrete_ident_view.to_definition_name name in
+        let bds = List.map ~f:(pgeneric_param_bd e.span) generics.params in
+        let name_str = U.Concrete_ident_view.to_definition_name name in
+        let name = F.id @@ name_str in
         let fields =
           List.concat_map
             ~f:(fun i ->
               let name = U.Concrete_ident_view.to_definition_name i.ti_ident in
-              match i.ti_v with
-              | TIType bounds ->
-                  let t = F.term @@ F.AST.Name (F.lid [ "Type" ]) in
-                  (F.id name, None, [], t)
-                  :: List.map
-                       ~f:(fun { trait; args; bindings = _ } ->
-                         let base =
-                           F.term @@ F.AST.Name (pconcrete_ident trait)
-                         in
-                         let args = List.map ~f:(pgeneric_value e.span) args in
-                         (F.id name, None, [], F.mk_e_app base args))
-                       bounds
-              | TIFn ty -> [ (F.id name, None, [], pty e.span ty) ])
+              let bds = pgenerics i.ti_span i.ti_generics in
+              let fields =
+                match i.ti_v with
+                | TIType bounds ->
+                    let t = F.term @@ F.AST.Name (F.lid [ "Type" ]) in
+                    (* let constraints = *)
+                    (*   List.map *)
+                    (*     ~f:(fun implements -> *)
+                    (*       { typ = TApp { ident = i.ti_ident } }) *)
+                    (*     bounds *)
+                    (* in *)
+                    (F.id name, None, [], t)
+                    :: List.map
+                         ~f:(fun { trait; args; bindings = _ } ->
+                           let base =
+                             F.term @@ F.AST.Name (pconcrete_ident trait)
+                           in
+                           let args =
+                             List.map ~f:(pgeneric_value e.span) args
+                           in
+                           (F.id name, None, [], F.mk_e_app base args))
+                         bounds
+                | TIFn ty -> [ (F.id name, None, [], pty e.span ty) ]
+              in
+              List.map ~f:Fn.id
+                (* ~f:(fun (n, q, a, ty) -> (n, q, a, F.mk_e_app bds ty)) *)
+                fields)
             items
         in
+        let constraints_fields =
+          generics.constraints
+          |> List.map ~f:(fun c ->
+                 let hash = Int.to_string ([%hash: generic_constraint] c) in
+                 let name = "__constraint_" ^ hash ^ "_" ^ name_str in
+                 let typ = pgeneric_constraint_type e.span c in
+                 (F.id name, None, [], typ))
+        in
+        let fields = constraints_fields @ fields in
         let fields =
           if List.is_empty fields then
-            [ (F.id "__marker_trait", None, [], pty e.span U.unit_typ) ]
+            let marker_field = "__marker_trait_" ^ name_str in
+            [ (F.id marker_field, None, [], pty e.span U.unit_typ) ]
           else fields
         in
         let tcdef = F.AST.TyconRecord (name, bds, None, [], fields) in
         let d = F.AST.Tycon (false, true, [ tcdef ]) in
         [ `Item { d; drange = F.dummyRange; quals = []; attrs = [] } ]
     | Impl { generics; self_ty = _; of_trait = trait, generic_args; items } ->
-        (* this unique name is stupid, we have disambiguators... *)
+        (* this unique name is stupid, we have disambiguators... And things will be refered differently! very stupid, TODO *)
         let unique_name_todo = "impl_" ^ Int.to_string ([%hash: item] e) in
         let pat = F.pat @@ F.AST.PatVar (F.id unique_name_todo, None, []) in
         let pat =
@@ -916,7 +946,12 @@ struct
         in
         let body = F.term @@ F.AST.Record (None, fields) in
         F.decls @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, body) ])
-    | HaxError details -> [ `Comment details ]
+    | HaxError details ->
+        [
+          `Comment
+            ("item error backend: " ^ details ^ "\n\nLast AST:\n"
+            ^ (U.LiftToFullAst.item e |> Print_rust.pitem_str));
+        ]
     | Use _ (* TODO: Not Yet Implemented *) | NotImplementedYet -> []
     | _ -> .
 end
@@ -955,6 +990,9 @@ let hardcoded_fstar_headers =
 
 let translate (bo : BackendOptions.t) (items : AST.item list) : Types.file list
     =
+  let show_view Concrete_ident.{ crate; path; definition } =
+    crate :: (path @ [ definition ]) |> String.concat ~sep:"::"
+  in
   U.group_items_by_namespace items
   |> Map.to_alist
   |> List.map ~f:(fun (ns, items) ->
@@ -974,6 +1012,7 @@ let translate (bo : BackendOptions.t) (items : AST.item list) : Types.file list
 
 open Phase_utils
 module DepGraph = Dependencies.Make (InputLanguage)
+module DepGraphR = Dependencies.Make (Features.Rust)
 
 module TransformToInputLanguage =
   [%functor_application
@@ -1001,8 +1040,21 @@ module TransformToInputLanguage =
 let apply_phases (bo : BackendOptions.t) (items : Ast.Rust.item list) :
     AST.item list =
   let items =
+    (* let hax_core_extraction = *)
+    (*   Sys.getenv "HAX_CORE_EXTRACTION_MODE" *)
+    (*   |> [%equal: string option] (Some "on") *)
+    (* in *)
+    (* if hax_core_extraction then *)
+    (*   let names = *)
+    (*     Core_names.names |> List.map ~f:(Concrete_ident.of_def_id Value) *)
+    (*   in *)
+    (*   DepGraphR.ItemGraph.transitive_dependencies_of_items names items *)
+    (* else *)
+    items
+  in
+  let items =
     TransformToInputLanguage.ditems items
     |> List.map ~f:U.Mappers.add_typ_ascription
-    |> DepGraph.name_me
+    (* |> DepGraph.name_me *)
   in
   items

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -351,13 +351,9 @@ struct
         if is_struct && is_record then pat_rec ()
         else
           let pat_name = F.pat @@ F.AST.PatName (pglobal_ident p.span name) in
-          let is_payload_record =
-            List.for_all ~f:(fun { field } -> is_field_an_index field) args
-            |> not
-          in
           F.pat_app pat_name
           @@
-          if is_payload_record then [ pat_rec () ]
+          if is_record then [ pat_rec () ]
           else List.map ~f:(fun { field; pat } -> ppat pat) args
     | PConstant { lit } -> F.pat @@ F.AST.PatConst (pliteral p.span lit)
     | _ -> .

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -65,6 +65,8 @@ module FStarNamePolicy = struct
 
   [@@@ocamlformat "disable"]
 
+  let index_field_transform index = "_" ^ index
+
   let reserved_words = Hash_set.of_list (module String) ["attributes";"noeq";"unopteq";"and";"assert";"assume";"begin";"by";"calc";"class";"default";"decreases";"effect";"eliminate";"else";"end";"ensures";"exception";"exists";"false";"friend";"forall";"fun";"λ";"function";"if";"in";"include";"inline";"inline_for_extraction";"instance";"introduce";"irreducible";"let";"logic";"match";"returns";"as";"module";"new";"new_effect";"layered_effect";"polymonadic_bind";"polymonadic_subcomp";"noextract";"of";"open";"opaque";"private";"quote";"range_of";"rec";"reifiable";"reify";"reflectable";"requires";"set_range_of";"sub_effect";"synth";"then";"total";"true";"try";"type";"unfold";"unfoldable";"val";"when";"with";"_";"__SOURCE_FILE__";"__LINE__";"match";"if";"let";"and"]
 end
 

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -889,7 +889,13 @@ struct
                            in
                            (F.id name, None, [], F.mk_e_app base args))
                          bounds
-                | TIFn ty -> [ (F.id name, None, [], pty e.span ty) ]
+                | TIFn ty ->
+                    let ty = pty e.span ty in
+                    let ty =
+                      F.term
+                      @@ F.AST.Product (pgenerics i.ti_span i.ti_generics, ty)
+                    in
+                    [ (F.id name, None, [], ty) ]
               in
               List.map ~f:Fn.id
                 (* ~f:(fun (n, q, a, ty) -> (n, q, a, F.mk_e_app bds ty)) *)

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -181,7 +181,7 @@ struct
           ("pglobal_ident: expected to be handled somewhere else: "
          ^ show_global_ident id)
 
-  let rec plocal_ident (e : LocalIdent.t) =
+  let plocal_ident (e : LocalIdent.t) =
     F.id
     @@
     if [%eq: LocalIdent.id] e.id magic_id_raw_local_ident then e.name

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -902,16 +902,19 @@ struct
                 fields)
             items
         in
-        let constraints_fields =
+        let constraints_fields : FStar_Parser_AST.tycon_record =
           generics.constraints
           |> List.map ~f:(fun c ->
-                 let hash = Int.to_string ([%hash: generic_constraint] c) in
-                 let name = "__constraint_" ^ hash ^ "_" ^ name_str in
+                 let name =
+                   "_super_" ^ Int.to_string ([%hash: generic_constraint] c)
+                 in
                  let typ = pgeneric_constraint_type e.span c in
-                 (F.id name, None, [], typ))
+                 (F.id name, None, [ F.Attrs.no_method ], typ))
         in
-        let fields = constraints_fields @ fields in
-        let fields =
+        let fields : FStar_Parser_AST.tycon_record =
+          constraints_fields @ fields
+        in
+        let fields : FStar_Parser_AST.tycon_record =
           if List.is_empty fields then
             let marker_field = "__marker_trait_" ^ name_str in
             [ (F.id marker_field, None, [], pty e.span U.unit_typ) ]

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -183,7 +183,11 @@ struct
     F.id
     @@
     if [%eq: LocalIdent.id] e.id magic_id_raw_local_ident then e.name
-    else U.Concrete_ident_view.local_name e.name
+    else
+      U.Concrete_ident_view.local_name
+        (match String.chop_prefix ~prefix:"impl " e.name with
+        | Some name -> "impl_" ^ Int.to_string ([%hash: string] name)
+        | _ -> e.name)
 
   let pgeneric_param_name (name : string) : string =
     String.lowercase
@@ -517,7 +521,7 @@ struct
         let tc = F.mk_e_app trait (*pty typ::*) args in
         F.AST.
           {
-            b = F.AST.NoName tc;
+            b = F.AST.Annotated (F.generate_fresh_ident (), tc);
             brange = F.dummyRange;
             blevel = Un;
             aqual = None;
@@ -850,21 +854,23 @@ struct
                            F.term @@ F.AST.Name (pconcrete_ident trait)
                          in
                          let args = List.map ~f:(pgeneric_value e.span) args in
-                         ( F.id
-                             (name ^ "_implements_"
-                             ^ U.Concrete_ident_view.to_definition_name trait),
-                           None,
-                           [],
-                           F.mk_e_app base args ))
+                         (F.id name, None, [], F.mk_e_app base args))
                        bounds
               | TIFn ty -> [ (F.id name, None, [], pty e.span ty) ])
             items
+        in
+        let fields =
+          if List.is_empty fields then
+            [ (F.id "__marker_trait", None, [], pty e.span U.unit_typ) ]
+          else fields
         in
         let tcdef = F.AST.TyconRecord (name, bds, None, [], fields) in
         let d = F.AST.Tycon (false, true, [ tcdef ]) in
         [ `Item { d; drange = F.dummyRange; quals = []; attrs = [] } ]
     | Impl { generics; self_ty = _; of_trait = trait, generic_args; items } ->
-        let pat = F.pat @@ F.AST.PatVar (F.id "impl", None, []) in
+        (* this unique name is stupid, we have disambiguators... *)
+        let unique_name_todo = "impl_" ^ Int.to_string ([%hash: item] e) in
+        let pat = F.pat @@ F.AST.PatVar (F.id unique_name_todo, None, []) in
         let pat =
           F.pat
           @@ F.AST.PatApp

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -511,11 +511,12 @@ struct
     | GPLifetime _ -> .
     | GPType { default = _ } ->
         let t = F.term @@ F.AST.Name (F.lid [ "Type" ]) in
-        F.mk_e_binder (F.AST.Annotated (plocal_ident ident, t))
+        F.mk_binder ~aqual:Implicit (F.AST.Annotated (plocal_ident ident, t))
     | GPType _ ->
         Error.unimplemented span ~details:"pgeneric_param_bd:Type with default"
     | GPConst { typ } ->
-        F.mk_e_binder (F.AST.Annotated (plocal_ident ident, pty span typ))
+        F.mk_binder ~aqual:Implicit
+          (F.AST.Annotated (plocal_ident ident, pty span typ))
 
   let pgeneric_param_ident span (p : generic_param) =
     match (pgeneric_param_bd span p).b with

--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -16,6 +16,8 @@ let setup_logs (options : Types.engine_options) =
   Logs.set_level level;
   Logs.set_reporter @@ Logs.format_reporter ()
 
+module Deps = Dependencies.Make (Features.Rust)
+
 let run (options : Types.engine_options) : Types.output =
   setup_logs options;
   if options.backend.debug_engine then Phase_utils.DebugBindPhase.enable ();
@@ -33,6 +35,8 @@ let run (options : Types.engine_options) : Types.output =
                     options.backend.translation_options.include_namespaces item)
                |> Result.ok_or_failwith
              with Failure e -> failwith e)
+      |> Deps.filter_by_inclusion_clauses
+           options.backend.translation_options.include_namespaces
     in
     Logs.info (fun m ->
         m "Applying phase for backend %s"

--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -20,7 +20,8 @@ module Deps = Dependencies.Make (Features.Rust)
 
 let run (options : Types.engine_options) : Types.output =
   setup_logs options;
-  if options.backend.debug_engine then Phase_utils.DebugBindPhase.enable ();
+  if options.backend.debug_engine |> Option.is_some then
+    Phase_utils.DebugBindPhase.enable ();
   let run (type options_type)
       (module M : Backend.T with type BackendOptions.t = options_type)
       (backend_options : options_type) : Types.file list =

--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -23,6 +23,7 @@ let run (options : Types.engine_options) : Types.output =
       (module M : Backend.T with type BackendOptions.t = options_type)
       (backend_options : options_type) : Types.file list =
     let open M in
+    Concrete_ident.ImplInfos.init options.impl_infos;
     let items =
       options.input
       |> List.concat_map ~f:(fun item ->

--- a/engine/bin/lib.mli
+++ b/engine/bin/lib.mli
@@ -1,3 +1,4 @@
-val read_options_from_stdin : (string -> Yojson.Safe.t) -> Hax_engine.Types.engine_options
-val main : Hax_engine.Types.engine_options -> unit
+val read_options_from_stdin :
+  (string -> Yojson.Safe.t) -> Hax_engine.Types.engine_options
 
+val main : Hax_engine.Types.engine_options -> unit

--- a/engine/default.nix
+++ b/engine/default.nix
@@ -64,6 +64,7 @@
         core
         re
         js_of_ocaml
+        ocamlgraph
       ]
       ++
       # F* dependencies

--- a/engine/dune-project
+++ b/engine/dune-project
@@ -40,6 +40,7 @@
         ppx_matches
         ppx_string
         logs
+        ocamlgraph
 
         js_of_ocaml-compiler
         zarith_stubs_js

--- a/engine/hax-engine.opam
+++ b/engine/hax-engine.opam
@@ -30,6 +30,7 @@ depends: [
   "ppx_matches"
   "ppx_string"
   "logs"
+  "ocamlgraph"
   "js_of_ocaml-compiler"
   "zarith_stubs_js"
   "batteries"

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -273,12 +273,23 @@ functor
         }
       | TParam of local_ident
       | TArrow of ty list * ty
-      | TProjectedAssociatedType of string
+      | TAssociatedType of { impl : impl_expr; item : concrete_ident }
+      | TOpaque of concrete_ident
 
     and generic_value =
       | GLifetime of { lt : todo; witness : F.lifetime }
       | GType of ty
       | GConst of expr
+
+    and impl_expr =
+      | Concrete of trait_ref
+      | LocalBound of { id : string }
+      | Parent of { impl : impl_expr; trait : trait_ref }
+      | Projection of { impl : impl_expr; item : concrete_ident }
+      | Dyn of trait_ref
+      | Builtin of trait_ref
+
+    and trait_ref = { trait : concrete_ident; args : generic_value list }
 
     and pat' =
       | PWild
@@ -434,6 +445,7 @@ functor
                 "DefaultClasses.default_reduce_features";
                 "binding_mode_reduce";
                 "span_reduce";
+                "concrete_ident_reduce";
               ];
           },
         visitors
@@ -449,6 +461,7 @@ functor
                 "DefaultClasses.default_mapreduce_features";
                 "binding_mode_mapreduce";
                 "span_mapreduce";
+                "concrete_ident_mapreduce";
               ];
           },
         visitors
@@ -464,6 +477,7 @@ functor
                 "DefaultClasses.default_map_features";
                 "binding_mode_map";
                 "span_map";
+                "concrete_ident_map";
               ];
           }]
 
@@ -478,62 +492,10 @@ functor
       | GPLifetime of { witness : (F.lifetime[@visitors.opaque]) }
       | GPType of { default : ty option }
       | GPConst of { typ : ty }
-    [@@deriving
-      show,
-        yojson,
-        hash,
-        eq,
-        visitors
-          {
-            variety = "reduce";
-            name = "generic_param_reduce";
-            ancestors = [ "expr_reduce" ];
-          },
-        visitors
-          {
-            variety = "mapreduce";
-            name = "generic_param_mapreduce";
-            ancestors = [ "expr_mapreduce" ];
-          },
-        visitors
-          {
-            variety = "map";
-            name = "generic_param_map";
-            ancestors = [ "expr_map" ];
-          }]
 
-    type trait_ref = {
-      trait : concrete_ident;
-      args : generic_value list;
-      bindings : todo list;
-    }
-    [@@deriving
-      show,
-        yojson,
-        hash,
-        eq,
-        visitors
-          {
-            variety = "reduce";
-            name = "trait_ref_reduce";
-            ancestors = [ "expr_reduce"; "concrete_ident_reduce" ];
-          },
-        visitors
-          {
-            variety = "mapreduce";
-            name = "trait_ref_mapreduce";
-            ancestors = [ "expr_mapreduce"; "concrete_ident_mapreduce" ];
-          },
-        visitors
-          {
-            variety = "map";
-            name = "trait_ref_map";
-            ancestors = [ "expr_map"; "concrete_ident_map" ];
-          }]
-
-    type generic_constraint =
+    and generic_constraint =
       | GCLifetime of todo * (F.lifetime[@visitors.opaque])
-      | GCType of { typ : ty; implements : trait_ref }
+      | GCType of { typ : ty; implements : trait_ref; id : string }
     [@@deriving
       show,
         yojson,
@@ -543,19 +505,19 @@ functor
           {
             variety = "reduce";
             name = "generic_constraint_reduce";
-            ancestors = [ "trait_ref_reduce" ];
+            ancestors = [ "expr_reduce" ];
           },
         visitors
           {
             variety = "mapreduce";
             name = "generic_constraint_mapreduce";
-            ancestors = [ "trait_ref_mapreduce" ];
+            ancestors = [ "expr_mapreduce" ];
           },
         visitors
           {
             variety = "map";
             name = "generic_constraint_map";
-            ancestors = [ "trait_ref_map" ];
+            ancestors = [ "expr_map" ];
           }]
 
     type param = { pat : pat; typ : ty; typ_span : span option; attrs : attrs }
@@ -649,12 +611,7 @@ functor
             variety = "reduce";
             name = "item_reduce";
             ancestors =
-              [
-                "generic_constraint_reduce";
-                "expr_reduce";
-                "generic_param_reduce";
-                "attrs_reduce";
-              ];
+              [ "generic_constraint_reduce"; "expr_reduce"; "attrs_reduce" ];
           },
         visitors
           {
@@ -664,7 +621,6 @@ functor
               [
                 "generic_constraint_mapreduce";
                 "expr_mapreduce";
-                "generic_param_mapreduce";
                 "attrs_mapreduce";
               ];
           },
@@ -672,13 +628,7 @@ functor
           {
             variety = "map";
             name = "item_map";
-            ancestors =
-              [
-                "generic_constraint_map";
-                "expr_map";
-                "generic_param_map";
-                "attrs_map";
-              ];
+            ancestors = [ "generic_constraint_map"; "expr_map"; "attrs_map" ];
           }]
 
     type modul = item list

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -603,6 +603,9 @@ functor
           of_trait : global_ident * generic_value list;
           items : impl_item list;
         }
+      | Alias of { name : concrete_ident; item : concrete_ident }
+          (** `Alias {name; item}` is basically a `use
+              <item> as _;` where `name` is the renamed ident. *)
       | Use of {
           path : string list;
           is_external : bool;

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -29,6 +29,7 @@ type concrete_ident = (Concrete_ident.t[@visitors.opaque])
     hash,
     compare,
     sexp,
+    hash,
     eq,
     visitors { variety = "reduce"; name = "concrete_ident_reduce" },
     visitors { variety = "mapreduce"; name = "concrete_ident_mapreduce" },
@@ -49,7 +50,7 @@ module Global_ident = struct
       | `TupleField of int * int
       | `Projector of [ `Concrete of concrete_ident | `TupleField of int * int ]
       ]
-    [@@deriving show, yojson, hash, compare, sexp, eq]
+    [@@deriving show, yojson, compare, hash, sexp, eq]
   end
 
   module M = struct

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -98,21 +98,22 @@ and attrs = attr list
 
 module LocalIdent = struct
   module T : sig
+    type kind = Typ | Cnst | Expr | LILifetime
+    [@@deriving show, yojson, hash, compare, sexp, eq]
+
     type id [@@deriving show, yojson, hash, compare, sexp, eq]
 
-    val var_id_of_int : int -> id
-    val ty_param_id_of_int : int -> id
-    val const_id_of_int : int -> id
+    val mk_id : kind -> int -> id
 
     type t = { name : string; id : id }
     [@@deriving show, yojson, hash, compare, sexp, eq]
   end = struct
-    type id = Typ of int | Cnst of int | Expr of int
+    type kind = Typ | Cnst | Expr | LILifetime
     [@@deriving show, yojson, hash, compare, sexp, eq]
 
-    let var_id_of_int id = Expr id
-    let ty_param_id_of_int id = Typ id
-    let const_id_of_int id = Cnst id
+    type id = kind * int [@@deriving show, yojson, hash, compare, sexp, eq]
+
+    let mk_id kind id = (kind, id)
 
     type t = { name : string; id : id }
     [@@deriving show, yojson, hash, compare, sexp, eq]

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -286,7 +286,12 @@ functor
       | Concrete of trait_ref
       | LocalBound of { id : string }
       | Parent of { impl : impl_expr; trait : trait_ref }
-      | Projection of { impl : impl_expr; item : concrete_ident }
+      | Projection of {
+          impl : impl_expr;
+          trait : trait_ref;
+          item : concrete_ident;
+        }
+      | ImplApp of { impl : impl_expr; args : impl_expr list }
       | Dyn of trait_ref
       | Builtin of trait_ref
 
@@ -496,7 +501,12 @@ functor
 
     and generic_constraint =
       | GCLifetime of todo * (F.lifetime[@visitors.opaque])
-      | GCType of { typ : ty; implements : trait_ref; id : string }
+      | GCType of {
+          bound : trait_ref;
+              (* trait_ref is always applied with the type the trait implements.
+                 For instance, `T: Clone` is actually `Clone<T> *)
+          id : string;
+        }
     [@@deriving
       show,
         yojson,

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -96,6 +96,17 @@ module Make (F : Features.T) = struct
         end
     end
 
+    module Concrete_ident = struct
+      include Set.M (Concrete_ident)
+
+      class ['s] monoid =
+        object
+          inherit ['s] VisitorsRuntime.monoid
+          method private zero = Set.empty (module Concrete_ident)
+          method private plus = Set.union
+        end
+    end
+
     module LocalIdent = struct
       include Set.M (LocalIdent)
 
@@ -172,6 +183,22 @@ module Make (F : Features.T) = struct
         (* method visit_GlobalVar (lvl : level) i = GlobalVar (f lvl i) *)
       end
 
+    let rename_concrete_idents
+        (f : visit_level -> Concrete_ident.t -> Concrete_ident.t) =
+      object
+        inherit [_] item_map as super
+        method visit_t (_lvl : visit_level) x = x
+        method visit_mutability _ (_lvl : visit_level) m = m
+        method! visit_concrete_ident (lvl : visit_level) ident = f lvl ident
+
+        method! visit_global_ident lvl (x : Global_ident.t) =
+          match x with
+          | `Concrete x -> `Concrete (f lvl x)
+          | _ -> super#visit_global_ident lvl x
+
+        method! visit_ty _ t = super#visit_ty TypeLevel t
+      end
+
     let rename_global_idents_item
         (f : visit_level -> global_ident -> global_ident) : item -> item =
       (rename_global_idents f)#visit_item ExprLevel
@@ -218,7 +245,7 @@ module Make (F : Features.T) = struct
   module Reducers = struct
     let collect_local_idents =
       object
-        inherit [_] expr_reduce as _super
+        inherit [_] item_reduce as _super
         inherit [_] Sets.LocalIdent.monoid as m
         method visit_t _ _ = m#zero
         method visit_mutability (_f : unit -> _ -> _) () _ = m#zero
@@ -227,13 +254,29 @@ module Make (F : Features.T) = struct
 
     let collect_global_idents =
       object
-        inherit ['self] expr_reduce as _super
+        inherit ['self] item_reduce as _super
         inherit [_] Sets.Global_ident.monoid as m
         method visit_t _ _ = m#zero
         method visit_mutability (_f : unit -> _ -> _) () _ = m#zero
 
         method! visit_global_ident (_env : unit) (x : Global_ident.t) =
           Set.singleton (module Global_ident) x
+      end
+
+    let collect_concrete_idents =
+      object
+        inherit ['self] item_reduce as super
+        inherit [_] Sets.Concrete_ident.monoid as m
+        method visit_t _ _ = m#zero
+        method visit_mutability (_f : unit -> _ -> _) () _ = m#zero
+
+        method! visit_global_ident (_env : unit) (x : Global_ident.t) =
+          match x with
+          | `Concrete x -> Set.singleton (module Concrete_ident) x
+          | _ -> super#visit_global_ident () x
+
+        method! visit_concrete_ident (_env : unit) (x : Concrete_ident.t) =
+          Set.singleton (module Concrete_ident) x
       end
 
     let variables_of_pat (p : pat) : Sets.LocalIdent.t =

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -408,7 +408,7 @@ module Make (F : Features.T) = struct
       name = prefix ^ free_suffix;
       id =
         (* TODO: freshness is local and name-only here... *)
-        LocalIdent.var_id_of_int (-1);
+        LocalIdent.mk_id Expr (-1);
     }
 
   let never_typ : ty =

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -165,6 +165,21 @@ module Make (F : Features.T) = struct
           expr e
       end
 
+    let rename_generic_constraints =
+      object
+        inherit [_] item_map as _super
+        method visit_t _ x = x
+        method visit_mutability _ _ m = m
+
+        method! visit_GCType (s : (string, string) Hashtbl.t) bound id =
+          let data = "i" ^ Int.to_string (Hashtbl.length s) in
+          let _ = Hashtbl.add s ~key:id ~data in
+          GCType { bound; id = data }
+
+        method! visit_LocalBound s id =
+          LocalBound { id = Hashtbl.find s id |> Option.value ~default:id }
+      end
+
     let rename_local_idents (f : local_ident -> local_ident) =
       object
         inherit [_] item_map as _super

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -613,7 +613,7 @@ module Make (F : Features.T) = struct
 
   module LiftToFullAst = struct
     let expr : AST.expr -> Ast.Full.expr = Stdlib.Obj.magic
-    let item : AST.expr -> Ast.Full.expr = Stdlib.Obj.magic
+    let item : AST.item -> Ast.Full.item = Stdlib.Obj.magic
   end
 
   let unbox_expr' (next : expr -> expr) (e : expr) : expr =

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -239,6 +239,8 @@ module MakeViewAPI (NP : NAME_POLICY) : VIEW_API = struct
       | Constructor { is_struct = false } ->
           ( List.drop_last_exn path,
             Option.value_exn type_name ^ "_" ^ definition )
+      | Field when List.last path |> [%equal: string option] type_name ->
+          (List.drop_last_exn path, definition)
       | _ -> (path, definition)
     in
     let definition = rename_definition path definition kind type_name in

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -178,6 +178,7 @@ end
 
 include T
 include View.T
+include (val Comparator.make ~compare ~sexp_of_t)
 
 include Concrete_ident_sig.Make (struct
   type t_ = t

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -75,6 +75,34 @@ module Imported = struct
     { did with path = List.map ~f did.path }
 end
 
+module ImplInfos = struct
+  let state :
+      ( Imported.def_id,
+        Types.ty * Types.binder_for__predicate_kind list )
+      Hashtbl.t
+      option
+      ref =
+    ref None
+
+  module T = struct
+    type t = Imported.def_id [@@deriving show, yojson, compare, sexp, eq, hash]
+  end
+
+  let init impl_infos =
+    state :=
+      impl_infos
+      |> List.map ~f:(map_fst Imported.of_def_id)
+      |> Hashtbl.of_alist_exn (module T)
+      |> Option.some
+
+  let get () =
+    match !state with
+    | None -> failwith "ImplInfos: state not initialized!"
+    | Some state -> state
+
+  let query k = Hashtbl.find_exn (get ()) k
+end
+
 module Kind = struct
   type t =
     | Type

--- a/engine/lib/concrete_ident/concrete_ident.mli
+++ b/engine/lib/concrete_ident/concrete_ident.mli
@@ -11,6 +11,7 @@ module Kind : sig
     | Macro
     | Trait
     | Impl
+    | AssociatedItem of t
   [@@deriving show, yojson, compare, sexp, eq, hash]
 end
 
@@ -19,15 +20,15 @@ val of_name : Kind.t -> name -> t
 val eq_name : name -> t -> bool
 val to_debug_string : t -> string
 
-module Create: sig
-  val fresh_module: from:t list -> t
-  val move_under: new_parent:t -> t -> t
+module Create : sig
+  val fresh_module : from:t list -> t
+  val move_under : new_parent:t -> t -> t
 end
 
 type view = { crate : string; path : string list; definition : string }
 
 val map_path_strings : f:(string -> string) -> t -> t
-val matches_namespace: Types.namespace -> t -> bool
+val matches_namespace : Types.namespace -> t -> bool
 
 include module type of struct
   include Concrete_ident_sig.Make (struct
@@ -40,6 +41,6 @@ module MakeViewAPI (NP : NAME_POLICY) : VIEW_API
 module DefaultNamePolicy : NAME_POLICY
 module DefaultViewAPI : VIEW_API
 
-
 type comparator_witness
+
 val comparator : (t, comparator_witness) Base.Comparator.comparator

--- a/engine/lib/concrete_ident/concrete_ident.mli
+++ b/engine/lib/concrete_ident/concrete_ident.mli
@@ -19,6 +19,11 @@ val of_name : Kind.t -> name -> t
 val eq_name : name -> t -> bool
 val to_debug_string : t -> string
 
+module Create: sig
+  val fresh_module: from:t list -> t
+  val move_under: new_parent:t -> t -> t
+end
+
 type view = { crate : string; path : string list; definition : string }
 
 val map_path_strings : f:(string -> string) -> t -> t

--- a/engine/lib/concrete_ident/concrete_ident.mli
+++ b/engine/lib/concrete_ident/concrete_ident.mli
@@ -34,3 +34,7 @@ end
 module MakeViewAPI (NP : NAME_POLICY) : VIEW_API
 module DefaultNamePolicy : NAME_POLICY
 module DefaultViewAPI : VIEW_API
+
+
+type comparator_witness
+val comparator : (t, comparator_witness) Base.Comparator.comparator

--- a/engine/lib/concrete_ident/concrete_ident.mli
+++ b/engine/lib/concrete_ident/concrete_ident.mli
@@ -1,6 +1,12 @@
 type t [@@deriving show, yojson, compare, sexp, eq, hash]
 type name = Concrete_ident_generated.name
 
+module ImplInfos : sig
+  val init :
+    (Types.def_id * (Types.ty * Types.binder_for__predicate_kind list)) list ->
+    unit
+end
+
 module Kind : sig
   type t =
     | Type

--- a/engine/lib/concrete_ident/generate.sh
+++ b/engine/lib/concrete_ident/generate.sh
@@ -11,7 +11,7 @@ cargo init --lib
 
 echo "$RUST_SOURCE" > src/lib.rs
 
-cargo hax json --def-ids -o - | jq -r "$(cat - <<JQ_SCRIPT
+cargo hax json --include-extra -o - | jq -r "$(cat - <<JQ_SCRIPT
   .def_ids | . as \$ids
   | map(  (.krate | ((.[0:1] | ascii_upcase) + .[1:]))
         + "__"

--- a/engine/lib/concrete_ident/names.rs
+++ b/engine/lib/concrete_ident/names.rs
@@ -111,6 +111,9 @@ mod hax {
     struct Failure;
     enum Never {}
 
+    // Only useful when HAX_CORE_EXTRACTION_MODE in `on`
+    enum MutRef {}
+
     fn repeat() {}
     fn update_at() {}
     // TODO: Should that live here? (this is F* specific)

--- a/engine/lib/dependencies.ml
+++ b/engine/lib/dependencies.ml
@@ -1,0 +1,265 @@
+open! Prelude
+
+module Make (F : Features.T) = struct
+  module AST = Ast.Make (F)
+  module U = Ast_utils.Make (F)
+  open Ast
+  open AST
+
+  let ident_of (item : item) : Concrete_ident.t = item.ident
+
+  module Namespace = struct
+    module T = struct
+      type t = string list [@@deriving show, yojson, compare, sexp, eq, hash]
+    end
+
+    module TT = struct
+      include T
+      include Comparator.Make (T)
+    end
+
+    include TT
+    module Set = Set.M (TT)
+
+    let of_concrete_ident ci : t =
+      let krate, path = Concrete_ident.DefaultViewAPI.to_namespace ci in
+      krate :: path
+  end
+
+  module ItemGraph = struct
+    module G = Graph.Persistent.Digraph.Concrete (Concrete_ident)
+    module Oper = Graph.Oper.P (G)
+
+    let vertices_of_item (i : item) : G.V.t list =
+      let ( @ ) = Set.union in
+      let v = U.Reducers.collect_concrete_idents in
+      let concat_map f =
+        List.map ~f >> Set.union_list (module Concrete_ident)
+      in
+      let set =
+        match i.v with
+        | Fn { name = _; generics; body; params } ->
+            v#visit_generics () generics
+            @ v#visit_expr () body
+            @ concat_map (v#visit_param ()) params
+        | TyAlias { name = _; generics; ty } ->
+            v#visit_generics () generics @ v#visit_ty () ty
+        | Type { name = _; generics; variants; is_struct = (_ : bool) } ->
+            v#visit_generics () generics
+            @ concat_map (v#visit_variant ()) variants
+        | IMacroInvokation { macro; argument = (_ : string); span; witness = _ }
+          ->
+            v#visit_concrete_ident () macro @ v#visit_span () span
+        | Trait { name = _; generics; items } ->
+            v#visit_generics () generics
+            @ concat_map (v#visit_trait_item ()) items
+        | Impl { generics; self_ty; of_trait; items } ->
+            v#visit_generics () generics
+            @ v#visit_ty () self_ty
+            @ v#visit_global_ident () (fst of_trait)
+            @ concat_map (v#visit_generic_value ()) (snd of_trait)
+            @ concat_map (v#visit_impl_item ()) items
+        | Alias { name = _; item } -> v#visit_concrete_ident () item
+        | Use _ | HaxError _ | NotImplementedYet ->
+            Set.empty (module Concrete_ident)
+      in
+      set |> Set.to_list
+
+    let vertices_of_items : item list -> G.E.t list =
+      List.concat_map ~f:(fun i ->
+          vertices_of_item i |> List.map ~f:(Fn.const i.ident &&& Fn.id))
+
+    let of_items : item list -> G.t =
+      vertices_of_items >> List.fold ~init:G.empty ~f:(G.add_edge >> uncurry)
+
+    let transitive_dependencies_of (selection : Concrete_ident.t list) (g : G.t)
+        : Concrete_ident.t Hash_set.t =
+      let set = Hash_set.create (module Concrete_ident) in
+      let rec visit vertex =
+        if Hash_set.mem set vertex |> not then (
+          Hash_set.add set vertex;
+          G.iter_succ visit g vertex)
+      in
+      List.filter ~f:(G.mem_vertex g) selection |> List.iter ~f:visit;
+      set
+
+    let transitive_dependencies_of_items (selection : Concrete_ident.t list)
+        (items : item list) : item list =
+      let g = of_items items in
+      let set = transitive_dependencies_of selection g in
+      items |> List.filter ~f:(ident_of >> Hash_set.mem set)
+
+    module MutRec = struct
+      module Bundle = struct
+        type t = concrete_ident list
+
+        let namespaces_of : t -> Namespace.Set.t =
+          List.map ~f:Namespace.of_concrete_ident
+          >> Set.of_list (module Namespace)
+
+        let homogeneous_namespace (ns : t) : bool =
+          Set.length (namespaces_of ns) <= 1
+      end
+
+      type t = {
+        mut_rec_bundles : Bundle.t list;
+        non_mut_rec : concrete_ident list;
+      }
+
+      module SCC = Graph.Components.Make (G)
+
+      let of_graph (g : G.t) : t =
+        let is_mut_rec_with_itself x = G.mem_edge g x x in
+        let mut_rec_bundles, non_mut_rec =
+          SCC.scc_list g
+          |> List.partition_map ~f:(function
+               | [] -> failwith "scc_list returned empty cluster"
+               | [ x ] when is_mut_rec_with_itself x |> not -> Second x
+               | bundle -> First bundle)
+        in
+        { mut_rec_bundles; non_mut_rec }
+
+      let all_homogeneous_namespace (g : G.t) =
+        List.for_all ~f:Bundle.homogeneous_namespace
+          (of_graph g).mut_rec_bundles
+    end
+
+    open Graph.Graphviz.Dot (struct
+      include G
+
+      let graph_attributes _ = []
+      let default_vertex_attributes _ = []
+      let vertex_name i = "\"" ^ Concrete_ident.show i ^ "\""
+
+      let vertex_attributes i =
+        [ `Label (Concrete_ident.DefaultViewAPI.to_definition_name i) ]
+
+      let get_subgraph i =
+        let ns = Namespace.of_concrete_ident i in
+        let sg_name = String.concat ~sep:"__" ns in
+        let label = String.concat ~sep:"::" ns in
+        let open Graph.Graphviz.DotAttributes in
+        Some { sg_name; sg_attributes = [ `Label label ]; sg_parent = None }
+
+      let default_edge_attributes _ = []
+      let edge_attributes _ = []
+    end)
+
+    let print oc items = output_graph oc (of_items items)
+  end
+
+  module ModGraph = struct
+    module G = Graph.Persistent.Digraph.Concrete (Namespace)
+
+    let of_items (items : item list) : G.t =
+      let ig = ItemGraph.of_items items in
+      assert (ItemGraph.MutRec.all_homogeneous_namespace ig);
+      List.map ~f:(ident_of >> (Namespace.of_concrete_ident &&& Fn.id)) items
+      |> Map.of_alist_multi (module Namespace)
+      |> Map.map
+           ~f:
+             (List.concat_map
+                ~f:
+                  (ItemGraph.G.succ ig
+                  >> List.map ~f:Namespace.of_concrete_ident)
+             >> Set.of_list (module Namespace)
+             >> Set.to_list)
+      |> Map.to_alist
+      |> List.concat_map ~f:(fun (x, ys) -> List.map ~f:(fun y -> (x, y)) ys)
+      |> List.fold ~init:G.empty ~f:(G.add_edge >> uncurry)
+
+    module SCC = Graph.Components.Make (G)
+
+    open Graph.Graphviz.Dot (struct
+      include G
+
+      let graph_attributes _ = []
+      let default_vertex_attributes _ = []
+      let vertex_name ns = "\"" ^ String.concat ~sep:"::" ns ^ "\""
+      let vertex_attributes _ = []
+      let get_subgraph _ = None
+      let default_edge_attributes _ = []
+      let edge_attributes _ = []
+    end)
+
+    let print oc items =
+      let g = of_items items in
+      let complicated_ones =
+        SCC.scc_list g
+        |> List.concat_map ~f:(function [] | [ _ ] -> [] | bundle -> bundle)
+      in
+      let g =
+        List.concat_map
+          ~f:(fun ns ->
+            List.map
+              ~f:(fun y -> (ns, y))
+              (G.succ g ns
+              |> List.filter
+                   ~f:(List.mem ~equal:[%equal: Namespace.t] complicated_ones)))
+          complicated_ones
+        |> List.fold ~init:G.empty ~f:(G.add_edge >> uncurry)
+      in
+      output_graph oc g
+  end
+
+  (* Construct the new item `f item` (say `item'`), and create a
+     "symbolic link" to `item'`. Returns a pair that consists in the
+     symbolic link and in `item'`. *)
+  let shallow_copy (f : item -> item) (item : item) : item * item =
+    let item' = f item in
+    ({ item with v = Alias { name = item.ident; item = item'.ident } }, item')
+
+  let name_me' (items : item list) : item list =
+    let g = ItemGraph.of_items items in
+    let from_ident ident : item option =
+      List.find ~f:(fun i -> [%equal: Concrete_ident.t] i.ident ident) items
+    in
+    let non_mut_rec, mut_rec_bundles =
+      let b = ItemGraph.MutRec.of_graph g in
+      let f = List.filter_map ~f:from_ident in
+      (f b.non_mut_rec, List.map ~f b.mut_rec_bundles)
+    in
+    let transform (bundle : item list) =
+      let ns : Concrete_ident.t =
+        Concrete_ident.Create.fresh_module ~from:(List.map ~f:ident_of bundle)
+      in
+      let new_name_under_ns : Concrete_ident.t -> Concrete_ident.t =
+        Concrete_ident.Create.move_under ~new_parent:ns
+      in
+      let renamings =
+        List.map ~f:(ident_of >> (Fn.id &&& new_name_under_ns)) bundle
+        |> Map.of_alist_exn (module Concrete_ident)
+      in
+      let rename =
+        let renamer _lvl i = Map.find renamings i |> Option.value ~default:i in
+        (U.Mappers.rename_concrete_idents renamer)#visit_item ExprLevel
+      in
+      let shallow, bundle =
+        List.map ~f:(shallow_copy rename) bundle |> List.unzip
+      in
+      bundle @ shallow
+    in
+    let mut_rec_bundles =
+      List.map
+        ~f:(fun bundle ->
+          if
+            List.map ~f:ident_of bundle
+            |> ItemGraph.MutRec.Bundle.homogeneous_namespace
+          then bundle
+          else transform bundle)
+        mut_rec_bundles
+    in
+    non_mut_rec @ List.concat_map ~f:Fn.id mut_rec_bundles
+
+  let name_me (items : item list) : item list =
+    let h f name items =
+      let file = Stdlib.open_out @@ "/tmp/graph_" ^ name ^ ".dot" in
+      f file items;
+      Stdlib.close_out file
+    in
+    h ItemGraph.print "items_before" items;
+    let items = name_me' items in
+    h ItemGraph.print "items_after" items;
+    h ModGraph.print "mods" items;
+    items
+end

--- a/engine/lib/dependencies.mli
+++ b/engine/lib/dependencies.mli
@@ -1,7 +1,8 @@
-module Make (F : Features.T): sig
-  module AST: module type of Ast.Make (F)
-  val name_me: AST.item list -> AST.item list
+module Make (F : Features.T) : sig
+  module AST : module type of Ast.Make (F)
 
-  val filter_by_inclusion_clauses: Types.inclusion_clause list ->
-      AST.item list -> AST.item list
+  val name_me : AST.item list -> AST.item list
+
+  val filter_by_inclusion_clauses :
+    Types.inclusion_clause list -> AST.item list -> AST.item list
 end

--- a/engine/lib/dependencies.mli
+++ b/engine/lib/dependencies.mli
@@ -1,4 +1,7 @@
 module Make (F : Features.T): sig
-      module AST: module type of Ast.Make (F)
-      val name_me: AST.item list -> AST.item list
+  module AST: module type of Ast.Make (F)
+  val name_me: AST.item list -> AST.item list
+
+  val filter_by_inclusion_clauses: Types.inclusion_clause list ->
+      AST.item list -> AST.item list
 end

--- a/engine/lib/dependencies.mli
+++ b/engine/lib/dependencies.mli
@@ -1,0 +1,4 @@
+module Make (F : Features.T): sig
+      module AST: module type of Ast.Make (F)
+      val name_me: AST.item list -> AST.item list
+end

--- a/engine/lib/dune
+++ b/engine/lib/dune
@@ -11,7 +11,8 @@
   base
   core
   logs
-  re)
+  re
+  ocamlgraph)
  (preprocessor_deps
   ; `ppx_inline` is used on the `Subtype` module, thus we need it at PPX time
   (file subtype.ml))

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1302,6 +1302,7 @@ module Make (Opts : OPTS) : MakeT = struct
               }
           in
           (* ident is supposed to always be an actual item, thus here we need to cheat a bit *)
+          (* TODO: is this DUMMY thing really needed? there's a `Use` segment (see #272) *)
           let def_id = item.owner_id in
           let def_id : Types.def_id =
             {

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -471,7 +471,7 @@ end) : EXPR = struct
           c_expr_assign lhs rhs
       | AssignOp { lhs; op; rhs } ->
           let lhs = c_expr lhs in
-          c_expr_assign lhs @@ c_binop op lhs (c_expr rhs) span typ
+          c_expr_assign lhs @@ c_binop op lhs (c_expr rhs) span lhs.typ
       | VarRef { id } -> LocalVar (local_ident Expr id)
       | Field { lhs; field } ->
           let lhs = c_expr lhs in

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -998,10 +998,7 @@ module Make (Opts : OPTS) : MakeT = struct
           unimplemented [ span ]
             "TODO: traits: no support for defaults in traits for now"
       | Const (ty, None) -> TIFn (c_ty span ty)
-      | ProvidedFn _ ->
-          unimplemented [ span ]
-            "TODO: traits: no support for defaults in funcitons for now"
-      | RequiredFn (sg, _) ->
+      | ProvidedFn (sg, _) | RequiredFn (sg, _) ->
           let (Thir.{ inputs; output; _ } : Thir.fn_decl) = sg.decl in
           let output =
             match output with

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -9,7 +9,6 @@ module Thir = struct
   type trait_item_kind = trait_item_kind_for__decorated_for__expr_kind
   type generic_param = generic_param_for__decorated_for__expr_kind
   type generic_param_kind = generic_param_kind_for__decorated_for__expr_kind
-  type where_predicate = where_predicate_for__decorated_for__expr_kind
   type trait_item = trait_item_for__decorated_for__expr_kind
 end
 
@@ -221,7 +220,7 @@ module Make (Opts : OPTS) : MakeT = struct
     val c_generic_value : Thir.span -> Thir.generic_arg -> generic_value
     val c_generics : Thir.generics -> generics
     val c_param : Thir.span -> Thir.param -> param
-    val c_trait_item' : Thir.span -> Thir.trait_item_kind -> trait_item'
+    val c_trait_item' : Thir.trait_item -> Thir.trait_item_kind -> trait_item'
   end
 
   (* BinOp to [core::ops::*] overloaded functions *)
@@ -897,8 +896,45 @@ module Make (Opts : OPTS) : MakeT = struct
       | Todo _ -> unimplemented [ span ] "type Todo"
     (* fun _ -> Ok Bool *)
 
-    and c_impl_expr (_span : Thir.span) (_ty : Thir.impl_expr) : impl_expr =
-      failwith "todo"
+    and c_impl_expr (span : Thir.span) (ie : Thir.impl_expr) : impl_expr =
+      let impl = c_impl_expr_atom span ie.impl in
+      match ie.args with
+      | [] -> impl
+      | args ->
+          let args = List.map ~f:(c_impl_expr span) args in
+          ImplApp { impl; args }
+
+    and c_impl_expr_atom (span : Thir.span) (ie : Thir.impl_expr_atom) :
+        impl_expr =
+      let c_trait_ref (tr : Thir.trait_ref) : trait_ref =
+        let trait = Concrete_ident.of_def_id Trait tr.def_id in
+        let args = List.map ~f:(c_generic_value span) tr.generic_args in
+        { trait; args }
+      in
+      match ie with
+      | Concrete { id; generics } ->
+          let trait = Concrete_ident.of_def_id Trait id in
+          let args = List.map ~f:(c_generic_value span) generics in
+          Concrete { trait; args }
+      | LocalBound { clause_id; path } ->
+          let init = LocalBound { id = clause_id } in
+          let f (impl : impl_expr) (chunk : Thir.impl_expr_path_chunk) =
+            match chunk with
+            | AssocItem (item, { trait_ref; _ }) ->
+                let trait = c_trait_ref trait_ref in
+                let kind : Concrete_ident.Kind.t =
+                  match item.kind with Const | Fn -> Value | Type -> Type
+                in
+                let item = Concrete_ident.of_def_id kind item.def_id in
+                Projection { impl; trait; item }
+            | Parent { trait_ref; _ } ->
+                let trait = c_trait_ref trait_ref in
+                Parent { impl; trait }
+          in
+          List.fold ~init ~f path
+      | Dyn { trait } -> Dyn (c_trait_ref trait)
+      | Builtin { trait } -> Builtin (c_trait_ref trait)
+      | Todo str -> failwith @@ "impl_expr_atom: Todo " ^ str
 
     and c_generic_value (span : Thir.span) (ty : Thir.generic_arg) :
         generic_value =
@@ -967,18 +1003,6 @@ module Make (Opts : OPTS) : MakeT = struct
     let c_predicate_kind span (p : Thir.predicate_kind) : trait_ref option =
       c_predicate_kind' span p |> Option.map ~f:fst
 
-    let c_constraint span (c : Thir.where_predicate) : generic_constraint list =
-      match c with
-      | BoundPredicate { bounded_ty; bounds; span; _ } ->
-          let typ = c_ty span bounded_ty in
-          let traits = List.filter_map ~f:(c_predicate_kind' span) bounds in
-          List.map
-            ~f:(fun (trait, id) : generic_constraint ->
-              GCType { typ; implements = trait; id })
-            traits
-      | RegionPredicate _ -> unimplemented [ span ] "region prediate"
-      | EqPredicate _ -> unimplemented [ span ] "EqPredicate"
-
     let list_dedup (equal : 'a -> 'a -> bool) : 'a list -> 'a list =
       let rec aux (seen : 'a list) (todo : 'a list) : 'a list =
         match todo with
@@ -990,14 +1014,19 @@ module Make (Opts : OPTS) : MakeT = struct
       aux []
 
     let c_generics (generics : Thir.generics) : generics =
+      let bounds =
+        List.filter_map ~f:(c_predicate_kind' generics.span) generics.bounds
+        |> List.map ~f:(fun (trait, id) : generic_constraint ->
+               GCType { bound = trait; id })
+      in
       {
         params = List.map ~f:c_generic_param generics.params;
-        constraints =
-          List.concat_map ~f:(c_constraint generics.span) generics.predicates
-          |> list_dedup equal_generic_constraint;
+        constraints = bounds |> list_dedup equal_generic_constraint;
       }
 
-    let c_trait_item' span (item : Thir.trait_item_kind) : trait_item' =
+    let c_trait_item' (super : Thir.trait_item) (item : Thir.trait_item_kind) :
+        trait_item' =
+      let span = super.span in
       match item with
       | Const (_, Some _) ->
           unimplemented [ span ]
@@ -1034,7 +1063,7 @@ module Make (Opts : OPTS) : MakeT = struct
     {
       ti_span = Span.of_thir item.span;
       ti_generics = { params; constraints };
-      ti_v = c_trait_item' item.span item.kind;
+      ti_v = c_trait_item' item item.kind;
       ti_ident;
       ti_attrs = c_item_attrs item.attributes;
     }

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1367,4 +1367,9 @@ let c_item inclusion_clauses (item : Thir.item) : (item list, error) Result.t =
       let inclusion_clauses = inclusion_clauses
     end) : MakeT)
   in
-  M.c_item item |> Result.return
+  M.c_item item
+  |> List.map
+       ~f:
+         (U.Mappers.rename_generic_constraints#visit_item
+            (Hashtbl.create (module String)))
+  |> Result.return

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -76,8 +76,8 @@ module Make (Opts : OPTS) : MakeT = struct
   let def_id kind (def_id : Thir.def_id) : global_ident =
     `Concrete (Concrete_ident.of_def_id kind def_id)
 
-  let local_ident (ident : Thir.local_ident) : local_ident =
-    { name = ident.name; id = LocalIdent.var_id_of_int 123 (* todo! *) }
+  let local_ident kind (ident : Thir.local_ident) : local_ident =
+    { name = ident.name; id = LocalIdent.mk_id kind 123 (* todo! *) }
 
   let int_ty_to_size : Thir.int_ty -> size = function
     | Isize -> SSize
@@ -504,7 +504,7 @@ module Make (Opts : OPTS) : MakeT = struct
         | AssignOp { lhs; op; rhs } ->
             let lhs = c_expr lhs in
             c_expr_assign lhs @@ c_binop op lhs (c_expr rhs) span typ
-        | VarRef { id } -> LocalVar (local_ident id)
+        | VarRef { id } -> LocalVar (local_ident Expr id)
         | Field { lhs; field } ->
             let lhs = c_expr lhs in
             let projector =
@@ -532,7 +532,7 @@ module Make (Opts : OPTS) : MakeT = struct
                 args = [ lhs ];
               }
         | GlobalName { id } -> GlobalVar (def_id Value id)
-        | UpvarRef { var_hir_id = id; _ } -> LocalVar (local_ident id)
+        | UpvarRef { var_hir_id = id; _ } -> LocalVar (local_ident Expr id)
         | Borrow { arg; borrow_kind = kind } ->
             let e' = c_expr arg in
             let kind = c_borrow_kind e.span kind in
@@ -562,7 +562,7 @@ module Make (Opts : OPTS) : MakeT = struct
             LocalVar
               {
                 name = id.name;
-                id = LocalIdent.const_id_of_int (MyInt64.to_int_exn id.index);
+                id = LocalIdent.mk_id Cnst (MyInt64.to_int_exn id.index);
               }
         | Repeat { value; count } ->
             let value = c_expr value in
@@ -742,7 +742,7 @@ module Make (Opts : OPTS) : MakeT = struct
             in
             let typ = c_ty pat.span ty in
             let mode = c_binding_mode pat.span mode in
-            let var = local_ident var in
+            let var = local_ident Expr var in
             PBinding { mut; mode; var; typ; subpat }
         | Variant { info; subpatterns; _ } ->
             let name =
@@ -887,11 +887,7 @@ module Make (Opts : OPTS) : MakeT = struct
           TOpaque (Concrete_ident.of_def_id Type def_id)
       | Param { index; name } ->
           (* TODO: [id] might not unique *)
-          TParam
-            {
-              name;
-              id = LocalIdent.ty_param_id_of_int (MyInt64.to_int_exn index);
-            }
+          TParam { name; id = LocalIdent.mk_id Typ (MyInt64.to_int_exn index) }
       | Error -> unimplemented [ span ] "type Error"
       | Dynamic _ -> unimplemented [ span ] "type Dynamic"
       | Generator _ -> unimplemented [ span ] "type Generator"
@@ -927,14 +923,19 @@ module Make (Opts : OPTS) : MakeT = struct
 
     let c_generic_param (param : Thir.generic_param) : generic_param =
       let ident =
+        let kind =
+          match (param.kind : Thir.generic_param_kind) with
+          | Lifetime _ -> LocalIdent.LILifetime
+          | Type _ -> LocalIdent.Typ
+          | Const _ -> LocalIdent.Cnst
+        in
         match param.name with
         | Fresh ->
             (* fail with ("[Fresh] ident? " ^ Thir.show_generic_param param) *)
             (* TODO might be wrong to just have a wildcard here *)
-            ({ name = "_"; id = LocalIdent.ty_param_id_of_int 123 }
-              : local_ident)
+            ({ name = "_"; id = LocalIdent.mk_id kind 123 } : local_ident)
         | Error -> assertion_failure [ param.span ] "[Error] ident"
-        | Plain n -> local_ident n
+        | Plain n -> local_ident kind n
       in
       let kind =
         match (param.kind : Thir.generic_param_kind) with
@@ -1183,7 +1184,7 @@ module Make (Opts : OPTS) : MakeT = struct
           in
           let { params; constraints } = c_generics generics in
           let self =
-            let id = LocalIdent.ty_param_id_of_int 0 (* todo *) in
+            let id = LocalIdent.mk_id Typ 0 (* todo *) in
             let ident = LocalIdent.{ name = "Self"; id } in
             let kind = GPType { default = None } in
             { ident; span; attrs = []; kind }

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -879,8 +879,12 @@ module Make (Opts : OPTS) : MakeT = struct
       | Tuple types ->
           let types = List.map ~f:(fun ty -> GType (c_ty span ty)) types in
           TApp { ident = `TupleType (List.length types); args = types }
-      | Alias _ -> TProjectedAssociatedType (Thir.show_ty ty)
-      (* | Opaque _ -> unimplemented [span] "type Opaque" *)
+      | Alias (_kind, { trait_def_id = Some (_did, impl_expr); def_id; _ }) ->
+          let impl = c_impl_expr span impl_expr in
+          let item = Concrete_ident.of_def_id Type def_id in
+          TAssociatedType { impl; item }
+      | Alias (_kind, { def_id; trait_def_id = None; _ }) ->
+          TOpaque (Concrete_ident.of_def_id Type def_id)
       | Param { index; name } ->
           (* TODO: [id] might not unique *)
           TParam
@@ -896,6 +900,9 @@ module Make (Opts : OPTS) : MakeT = struct
       | Infer _ -> unimplemented [ span ] "type Infer"
       | Todo _ -> unimplemented [ span ] "type Todo"
     (* fun _ -> Ok Bool *)
+
+    and c_impl_expr (_span : Thir.span) (_ty : Thir.impl_expr) : impl_expr =
+      failwith "todo"
 
     and c_generic_value (span : Thir.span) (ty : Thir.generic_arg) :
         generic_value =
@@ -943,33 +950,30 @@ module Make (Opts : OPTS) : MakeT = struct
       let attrs = c_attrs param.attributes in
       { ident; span; attrs; kind }
 
-    let c_predicate_kind span (p : Thir.predicate_kind) : trait_ref option =
+    let c_predicate_kind' span (p : Thir.predicate_kind) :
+        (trait_ref * string) option =
       match p with
       | Clause
-          {
-            kind = Trait { is_positive = true; is_const = _; trait_ref };
-            id = _;
-          } ->
+          { kind = Trait { is_positive = true; is_const = _; trait_ref }; id }
+        ->
           let args =
             List.map ~f:(c_generic_value span) trait_ref.generic_args
           in
-          Some
-            {
-              trait = Concrete_ident.of_def_id Trait trait_ref.def_id;
-              args;
-              bindings = [];
-            }
+          let trait = Concrete_ident.of_def_id Trait trait_ref.def_id in
+          Some ({ trait; args }, id)
       | _ -> None
+
+    let c_predicate_kind span (p : Thir.predicate_kind) : trait_ref option =
+      c_predicate_kind' span p |> Option.map ~f:fst
 
     let c_constraint span (c : Thir.where_predicate) : generic_constraint list =
       match c with
       | BoundPredicate { bounded_ty; bounds; span; _ } ->
           let typ = c_ty span bounded_ty in
-          let traits = List.map ~f:(c_predicate_kind span) bounds in
-          let traits = List.filter_map ~f:Fn.id traits in
+          let traits = List.filter_map ~f:(c_predicate_kind' span) bounds in
           List.map
-            ~f:(fun trait : generic_constraint ->
-              GCType { typ; implements = trait })
+            ~f:(fun (trait, id) : generic_constraint ->
+              GCType { typ; implements = trait; id })
             traits
       | RegionPredicate _ -> unimplemented [ span ] "region prediate"
       | EqPredicate _ -> unimplemented [ span ] "EqPredicate"

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -384,7 +384,8 @@ module Make (Opts : OPTS) : MakeT = struct
             let then_ = c_expr then' in
             let else_ = Option.map ~f:c_expr else_opt in
             If { cond; else_; then_ }
-        | Call { args; fn_span = _; from_hir_call = _; fun'; ty = _ } ->
+        | Call { args; fn_span = _; impl = _; from_hir_call = _; fun'; ty = _ }
+          ->
             let args = List.map ~f:c_expr args in
             let f = c_expr fun' in
             App { f; args }
@@ -944,7 +945,11 @@ module Make (Opts : OPTS) : MakeT = struct
 
     let c_predicate_kind span (p : Thir.predicate_kind) : trait_ref option =
       match p with
-      | Clause (Trait { is_positive = true; is_const = _; trait_ref }) ->
+      | Clause
+          {
+            kind = Trait { is_positive = true; is_const = _; trait_ref };
+            id = _;
+          } ->
           let args =
             List.map ~f:(c_generic_value span) trait_ref.generic_args
           in

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -33,8 +33,6 @@ let unsafe_block (span : Thir.span list) =
   let kind = T.UnsafeBlock in
   Diagnostics.SpanFreeError.raise ~span ThirImport kind
 
-let todo (span : Thir.span) = unimplemented [ span ] "TODO"
-
 module Ast = struct
   include Ast
   include Rust
@@ -55,1319 +53,1259 @@ type error =
   | IllTypedIntLiteral
 [@@deriving show]
 
-module type OPTS = sig
-  val inclusion_clauses : Types.inclusion_clause list
-end
+let def_id kind (def_id : Thir.def_id) : global_ident =
+  `Concrete (Concrete_ident.of_def_id kind def_id)
 
-module type MakeT = sig
-  val c_item : Types.item_for__decorated_for__expr_kind -> Ast.Rust.item list
-end
+let local_ident kind (ident : Thir.local_ident) : local_ident =
+  { name = ident.name; id = LocalIdent.mk_id kind 123 (* todo! *) }
 
-module Make (Opts : OPTS) : MakeT = struct
-  let included_inclusion_clauses (def_id : Concrete_ident.t) :
-      Types.inclusion_kind =
-    Opts.inclusion_clauses |> List.rev
-    |> List.find ~f:(fun clause ->
-           Concrete_ident.matches_namespace clause.Types.namespace def_id)
-    |> Option.map ~f:(fun (clause : Types.inclusion_clause) -> clause.kind)
-    |> Option.value ~default:(Included : Types.inclusion_kind)
+let int_ty_to_size : Thir.int_ty -> size = function
+  | Isize -> SSize
+  | I8 -> S8
+  | I16 -> S16
+  | I32 -> S32
+  | I64 -> S64
+  | I128 -> S128
 
-  let def_id kind (def_id : Thir.def_id) : global_ident =
-    `Concrete (Concrete_ident.of_def_id kind def_id)
+let uint_ty_to_size : Thir.uint_ty -> size = function
+  | Usize -> SSize
+  | U8 -> S8
+  | U16 -> S16
+  | U32 -> S32
+  | U64 -> S64
+  | U128 -> S128
 
-  let local_ident kind (ident : Thir.local_ident) : local_ident =
-    { name = ident.name; id = LocalIdent.mk_id kind 123 (* todo! *) }
+let c_int_ty (ty : Thir.int_ty) : int_kind =
+  { size = int_ty_to_size ty; signedness = Signed }
 
-  let int_ty_to_size : Thir.int_ty -> size = function
-    | Isize -> SSize
-    | I8 -> S8
-    | I16 -> S16
-    | I32 -> S32
-    | I64 -> S64
-    | I128 -> S128
+let c_uint_ty (ty : Thir.uint_ty) : int_kind =
+  { size = uint_ty_to_size ty; signedness = Unsigned }
 
-  let uint_ty_to_size : Thir.uint_ty -> size = function
-    | Usize -> SSize
-    | U8 -> S8
-    | U16 -> S16
-    | U32 -> S32
-    | U64 -> S64
-    | U128 -> S128
+let c_mutability (witness : 'a) : bool -> 'a Ast.mutability = function
+  | true -> Mutable witness
+  | false -> Immutable
 
-  let c_int_ty (ty : Thir.int_ty) : int_kind =
-    { size = int_ty_to_size ty; signedness = Signed }
+let c_borrow_kind span : Thir.borrow_kind -> borrow_kind = function
+  | Shared -> Shared
+  | Shallow -> unimplemented [ span ] "Shallow borrows"
+  | Unique -> Unique
+  | Mut _ -> Mut W.mutable_reference
 
-  let c_uint_ty (ty : Thir.uint_ty) : int_kind =
-    { size = uint_ty_to_size ty; signedness = Unsigned }
+let c_binding_mode span : Thir.binding_mode -> binding_mode = function
+  | ByValue -> ByValue
+  | ByRef k -> ByRef (c_borrow_kind span k, W.reference)
 
-  let c_mutability (witness : 'a) : bool -> 'a Ast.mutability = function
-    | true -> Mutable witness
-    | false -> Immutable
+let unit_typ : ty = TApp { ident = `TupleType 0; args = [] }
 
-  let c_borrow_kind span : Thir.borrow_kind -> borrow_kind = function
-    | Shared -> Shared
-    | Shallow -> unimplemented [ span ] "Shallow borrows"
-    | Unique -> Unique
-    | Mut _ -> Mut W.mutable_reference
+let unit_expr span : expr =
+  { typ = unit_typ; span; e = Ast.GlobalVar (`TupleCons 0) }
 
-  let c_binding_mode span : Thir.binding_mode -> binding_mode = function
-    | ByValue -> ByValue
-    | ByRef k -> ByRef (c_borrow_kind span k, W.reference)
+let wild_pat span : ty -> pat = fun typ -> { typ; span; p = PWild }
 
-  let unit_typ : ty = TApp { ident = `TupleType 0; args = [] }
+let c_logical_op : Thir.logical_op -> logical_op = function
+  | And -> And
+  | Or -> Or
 
-  let unit_expr span : expr =
-    { typ = unit_typ; span; e = Ast.GlobalVar (`TupleCons 0) }
-
-  let wild_pat span : ty -> pat = fun typ -> { typ; span; p = PWild }
-
-  let c_logical_op : Thir.logical_op -> logical_op = function
-    | And -> And
-    | Or -> Or
-
-  let c_attr (attr : Thir.attribute) : attr =
-    let kind =
-      match attr.kind with
-      | Normal { item = { args; path; tokens = subtokens }; tokens } ->
-          let args_tokens =
-            match args with Delimited { tokens; _ } -> Some tokens | _ -> None
-          in
-          let tokens =
-            let ( || ) = Option.first_some in
-            Option.value ~default:"" (args_tokens || tokens || subtokens)
-          in
-          Tool { path; tokens }
-      | DocComment (kind, body) ->
-          let kind =
-            match kind with Thir.Line -> DCKLine | Thir.Block -> DCKBlock
-          in
-          DocComment { kind; body }
-    in
-    { kind; span = Span.of_thir attr.span }
-
-  let c_attrs : Thir.attribute list -> attrs = List.map ~f:c_attr
-
-  let c_item_attrs (attrs : Thir.item_attributes) : attrs =
-    (* TODO: This is a quite coarse approximation, we need to reflect
-       that parent/self structure in our AST. *)
-    c_attrs (attrs.parent_attributes @ attrs.attributes)
-
-  type extended_literal =
-    | EL_Lit of literal
-    | EL_U8Array of literal list (* EL_U8Array only encodes arrays of [u8]s *)
-
-  let c_lit' span negative (lit : Thir.lit_kind) (ty : ty) : extended_literal =
-    let mk l = EL_Lit l in
-    let mku8 (n : int) =
-      let kind = { size = S8; signedness = Unsigned } in
-      Int { value = Int.to_string n; kind; negative = false }
-    in
-    let error kind =
-      assertion_failure [ span ]
-        ("[import_thir:literal] got a " ^ kind ^ " literal, expected " ^ kind
-       ^ " type, got type ["
-        ^ [%show: ty] ty
-        ^ "] instead.")
-    in
-    match lit with
-    | Err ->
-        assertion_failure [ span ]
-          "[import_thir:literal] got an error literal: this means the Rust \
-           compiler or Hax's frontend probably reported errors above."
-    | Str (str, _) -> mk @@ String str
-    | CStr (l, _) | ByteStr (l, _) -> EL_U8Array (List.map ~f:mku8 l)
-    | Byte n -> mk @@ mku8 n
-    | Char s -> mk @@ Char s
-    | Int (value, _kind) ->
-        mk
-        @@ Int
-             {
-               value;
-               negative;
-               kind = (match ty with TInt k -> k | _ -> error "integer");
-             }
-    | Float (value, _kind) ->
-        mk
-        @@ Float
-             {
-               value;
-               negative;
-               kind = (match ty with TFloat k -> k | _ -> error "float");
-             }
-    | Bool b -> mk @@ Bool b
-
-  let c_lit span neg (lit : Thir.spanned_for__lit_kind) : ty -> extended_literal
-      =
-    c_lit' span neg lit.node
-
-  let resugar_index_mut (e : expr) : (expr * expr) option =
-    match (U.unbox_underef_expr e).e with
-    | App
-        {
-          f = { e = GlobalVar (`Concrete meth); _ };
-          args = [ { e = Borrow { e = x; _ }; _ }; index ];
-        }
-      when Concrete_ident.eq_name Core__ops__index__IndexMut__index_mut meth ->
-        Some (x, index)
-    | App { f = { e = GlobalVar (`Concrete meth); _ }; args = [ x; index ] }
-      when Concrete_ident.eq_name Core__ops__index__Index__index meth ->
-        Some (x, index)
-    | _ -> None
-
-  module type EXPR = sig
-    val c_expr : Thir.decorated_for__expr_kind -> expr
-    val c_ty : Thir.span -> Thir.ty -> ty
-    val c_generic_value : Thir.span -> Thir.generic_arg -> generic_value
-    val c_generics : Thir.generics -> generics
-    val c_param : Thir.span -> Thir.param -> param
-    val c_trait_item' : Thir.trait_item -> Thir.trait_item_kind -> trait_item'
-  end
-
-  (* BinOp to [core::ops::*] overloaded functions *)
-
-  module Make (CTX : sig
-    val is_core_item : bool
-  end) : EXPR = struct
-    let c_binop (op : Thir.bin_op) (lhs : expr) (rhs : expr) (span : span)
-        (typ : ty) =
-      let overloaded_names_of_binop : Thir.bin_op -> Concrete_ident.name =
-        function
-        | Add -> Core__ops__arith__Add__add
-        | Sub -> Core__ops__arith__Sub__sub
-        | Mul -> Core__ops__arith__Mul__mul
-        | Div -> Core__ops__arith__Div__div
-        | Rem -> Core__ops__arith__Rem__rem
-        | BitXor -> Core__ops__bit__BitXor__bitxor
-        | BitAnd -> Core__ops__bit__BitAnd__bitand
-        | BitOr -> Core__ops__bit__BitOr__bitor
-        | Shl -> Core__ops__bit__Shl__shl
-        | Shr -> Core__ops__bit__Shr__shr
-        | Lt -> Core__cmp__PartialOrd__lt
-        | Le -> Core__cmp__PartialOrd__le
-        | Ne -> Core__cmp__PartialEq__ne
-        | Ge -> Core__cmp__PartialOrd__ge
-        | Gt -> Core__cmp__PartialOrd__gt
-        | Eq -> Core__cmp__PartialEq__eq
-        | Offset -> Core__ptr__const_ptr__Impl__offset
-      in
-      let primitive_names_of_binop : Thir.bin_op -> Concrete_ident.name =
-        function
-        | Add -> Rust_primitives__u128__add
-        | Sub -> Rust_primitives__u128__sub
-        | Mul -> Rust_primitives__u128__mul
-        | Div -> Rust_primitives__u128__div
-        | Rem -> Rust_primitives__u128__rem
-        | BitXor -> Rust_primitives__u128__bit_xor
-        | BitAnd -> Rust_primitives__u128__bit_and
-        | BitOr -> Rust_primitives__u128__bit_or
-        | Shl -> Rust_primitives__u128__shl
-        | Shr -> Rust_primitives__u128__shr
-        | Lt -> Rust_primitives__u128__lt
-        | Le -> Rust_primitives__u128__le
-        | Ne -> Rust_primitives__u128__ne
-        | Ge -> Rust_primitives__u128__ge
-        | Gt -> Rust_primitives__u128__gt
-        | Eq -> Rust_primitives__u128__eq
-        | Offset -> Rust_primitives__offset
-      in
-      let name =
-        if CTX.is_core_item then
-          let assert_type_eq t1 t2 =
-            if not (U.ty_equality t1 t2) then
-              assertion_failure (Span.to_thir span)
-                ("Binary operation: expected LHS and RHS to have the same \
-                  type, instead LHS has type ["
-                ^ [%show: ty] t1
-                ^ "] while RHS has type ["
-                ^ [%show: ty] t2
-                ^ "]")
-          in
-          let int =
-            ("int", function TInt k -> Some (show_int_kind k) | _ -> None)
-          in
-          let float =
-            ( "float",
-              function TFloat k -> Some (show_float_kind k) | _ -> None )
-          in
-          let bool = ("bool", function TBool -> Some "bool" | _ -> None) in
-          let concat_tup sep (x, y) = x ^ sep ^ y in
-          let ( <*> ) (x, f) (y, g) =
-            ( x ^ "*" ^ y,
-              f *** g >> uncurry Option.both >> Option.map ~f:(concat_tup "_")
-            )
-          in
-          let both (e, f) =
-            ( e ^ "*" ^ e,
-              fun (t1, t2) ->
-                assert_type_eq t1 t2;
-                f t1 )
-          in
-          let ( <|> ) (x, f) (y, g) =
-            (x ^ " or" ^ y, fun v -> match f v with None -> g v | v -> v)
-          in
-          let name = primitive_names_of_binop op in
-          let expected, f =
-            match op with
-            | Add | Sub | Mul | Div -> both int <|> both float
-            | Rem -> both int
-            | BitXor | BitAnd | BitOr -> both int <|> both bool
-            | Shl | Shr -> int <*> int
-            | Lt | Le | Ne | Ge | Gt -> both int <|> both float
-            | Eq -> both int <|> both float <|> both bool
-            | Offset -> ("", fun _ -> Some "")
-          in
-          match f (lhs.typ, rhs.typ) with
-          | Some with_ ->
-              Concrete_ident.of_name Value name
-              |> Concrete_ident.map_path_strings ~f:(function
-                   | "u128" -> with_
-                   | s -> s)
-          | None ->
-              assertion_failure (Span.to_thir span)
-                ("Binary operation: expected " ^ expected ^ " type, got "
-                ^ [%show: ty] lhs.typ)
-        else Concrete_ident.of_name Value @@ overloaded_names_of_binop op
-      in
-      U.call' (`Concrete name) [ lhs; rhs ] span typ
-
-    let rec c_expr (e : Thir.decorated_for__expr_kind) : expr =
-      try c_expr_unwrapped e
-      with Diagnostics.SpanFreeError.Exn (Data (ctx, kind)) ->
-        let typ : ty =
-          try c_ty e.span e.ty
-          with Diagnostics.SpanFreeError.Exn _ -> U.hax_failure_typ
+let c_attr (attr : Thir.attribute) : attr =
+  let kind =
+    match attr.kind with
+    | Normal { item = { args; path; tokens = subtokens }; tokens } ->
+        let args_tokens =
+          match args with Delimited { tokens; _ } -> Some tokens | _ -> None
         in
-        let span = Span.of_thir e.span in
-        U.hax_failure_expr' span typ (ctx, kind)
-          ([%show: Thir.decorated_for__expr_kind] e)
-
-    and c_expr_unwrapped (e : Thir.decorated_for__expr_kind) : expr =
-      let call f args = App { f; args = List.map ~f:c_expr args } in
-      let typ = c_ty e.span e.ty in
-      let span = Span.of_thir e.span in
-      let mk_global typ v : expr = { span; typ; e = GlobalVar v } in
-      let ( ->. ) a b = TArrow (a, b) in
-      let (v : expr') =
-        match e.contents with
-        | MacroInvokation { argument; macro_ident; _ } ->
-            MacroInvokation
-              {
-                args = argument;
-                macro = def_id Macro macro_ident;
-                witness = W.macro;
-              }
-        | If
-            {
-              cond = { contents = Let { expr = scrutinee; pat }; _ };
-              else_opt;
-              then';
-              _;
-            } ->
-            let scrutinee = c_expr scrutinee in
-            let arm_pat = c_pat pat in
-            let then_ = c_expr then' in
-            let else_ =
-              Option.value ~default:(U.unit_expr span)
-              @@ Option.map ~f:c_expr else_opt
-            in
-            let arm_then =
-              { arm = { arm_pat; body = then_ }; span = then_.span }
-            in
-            let arm_else =
-              let arm_pat = { arm_pat with p = PWild } in
-              { arm = { arm_pat; body = else_ }; span = else_.span }
-            in
-            Match { scrutinee; arms = [ arm_then; arm_else ] }
-        | If { cond; else_opt; then'; _ } ->
-            let cond = c_expr cond in
-            let then_ = c_expr then' in
-            let else_ = Option.map ~f:c_expr else_opt in
-            If { cond; else_; then_ }
-        | Call { args; fn_span = _; impl; from_hir_call = _; fun'; ty = _ } ->
-            let args = List.map ~f:c_expr args in
-            let f =
-              let f = c_expr fun' in
-              match (impl, fun'.contents) with
-              | Some _, GlobalName { id } ->
-                  { f with e = GlobalVar (def_id (AssociatedItem Value) id) }
-              | _ -> f
-            in
-            App { f; args }
-        | Box { value } ->
-            (U.call Rust_primitives__hax__box_new [ c_expr value ] span typ).e
-        | Deref { arg } ->
-            let inner_typ = c_ty arg.span arg.ty in
-            call (mk_global ([ inner_typ ] ->. typ) @@ `Primitive Deref) [ arg ]
-        | Binary { lhs; rhs; op } ->
-            (c_binop op (c_expr lhs) (c_expr rhs) span typ).e
-        | LogicalOp { lhs; rhs; op } ->
-            let lhs_type = c_ty lhs.span lhs.ty in
-            let rhs_type = c_ty rhs.span rhs.ty in
-            call
-              (mk_global ([ lhs_type; rhs_type ] ->. typ)
-              @@ `Primitive (LogicalOp (c_logical_op op)))
-              [ lhs; rhs ]
-        | Unary { arg; op } ->
-            (U.call
-               (match op with
-               | Not -> Core__ops__bit__Not__not
-               | Neg -> Core__ops__arith__Neg__neg)
-               [ c_expr arg ]
-               span typ)
-              .e
-        | Cast { source } ->
-            let source_type = c_ty source.span source.ty in
-            call
-              (mk_global ([ source_type ] ->. typ) @@ `Primitive Cast)
-              [ source ]
-        | Use { source } -> (c_expr source).e
-        | NeverToAny { source } ->
-            (U.call Rust_primitives__hax__never_to_any
-               [ c_expr source ]
-               span typ)
-              .e
-        (* TODO: this is incorrect (NeverToAny) *)
-        | Pointer { cast; source } -> c_pointer e typ span cast source
-        | Loop { body } ->
-            let body = c_expr body in
-            Loop
-              {
-                body;
-                kind = UnconditionalLoop;
-                state = None;
-                label = None;
-                witness = W.loop;
-              }
-        | Match { scrutinee; arms } ->
-            let scrutinee = c_expr scrutinee in
-            let arms = List.map ~f:c_arm arms in
-            Match { scrutinee; arms }
-        | Let _ -> unimplemented [ e.span ] "Let"
-        | Block { safety_mode = BuiltinUnsafe | ExplicitUnsafe; _ } ->
-            unsafe_block [ e.span ]
-        | Block o ->
-            (* if there is no expression & the last expression is ⊥, just use that *)
-            let lift_last_statement_as_expr_if_possible expr stmts
-                (ty : Thir.ty) =
-              match (ty, expr, List.drop_last stmts, List.last stmts) with
-              | ( Thir.Never,
-                  None,
-                  Some stmts,
-                  Some ({ kind = Thir.Expr { expr; _ }; _ } : Thir.stmt) ) ->
-                  (stmts, Some expr)
-              | _ -> (stmts, expr)
-            in
-            let o_stmts, o_expr =
-              lift_last_statement_as_expr_if_possible o.expr o.stmts e.ty
-            in
-            let init =
-              Option.map
-                ~f:(fun e ->
-                  let e = c_expr e in
-                  { e with e = Block (e, W.block) })
-                o_expr
-              |> Option.value ~default:(unit_expr span)
-            in
-            let { e; _ } =
-              List.fold_right o_stmts ~init ~f:(fun { kind; _ } body ->
-                  match kind with
-                  | Expr { expr = rhs; _ } ->
-                      let rhs = c_expr rhs in
-                      let e =
-                        Let
-                          {
-                            monadic = None;
-                            lhs = wild_pat rhs.span rhs.typ;
-                            rhs;
-                            body;
-                          }
-                      in
-                      { e; typ; span = Span.union rhs.span body.span }
-                  | Let { else_block = Some _; _ } ->
-                      unimplemented ~issue_id:155 [ e.span ]
-                        "Sorry, Hax does not support [let-else] (see \
-                         https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) \
-                         for now."
-                  | Let { initializer' = None; _ } ->
-                      unimplemented ~issue_id:156 [ e.span ]
-                        "Sorry, Hax does not support declare-first let \
-                         bindings (see \
-                         https://doc.rust-lang.org/rust-by-example/variable_bindings/declare.html) \
-                         for now."
-                  | Let { pattern = lhs; initializer' = Some rhs; _ } ->
-                      let lhs = c_pat lhs in
-                      let rhs = c_expr rhs in
-                      let e = Let { monadic = None; lhs; rhs; body } in
-                      { e; typ; span = Span.union rhs.span body.span })
-            in
-            e
-        | Assign { lhs; rhs } ->
-            let lhs = c_expr lhs in
-            let rhs = c_expr rhs in
-            c_expr_assign lhs rhs
-        | AssignOp { lhs; op; rhs } ->
-            let lhs = c_expr lhs in
-            c_expr_assign lhs @@ c_binop op lhs (c_expr rhs) span typ
-        | VarRef { id } -> LocalVar (local_ident Expr id)
-        | Field { lhs; field } ->
-            let lhs = c_expr lhs in
-            let projector =
-              GlobalVar
-                (`Projector (`Concrete (Concrete_ident.of_def_id Field field)))
-            in
-            let span = Span.of_thir e.span in
-            App
-              {
-                f = { e = projector; typ = TArrow ([ lhs.typ ], typ); span };
-                args = [ lhs ];
-              }
-        | TupleField { lhs; field } ->
-            (* TODO: refactor *)
-            let tuple_len = 0 (* todo, lookup type *) in
-            let lhs = c_expr lhs in
-            let projector =
-              GlobalVar
-                (`Projector (`TupleField (Int.of_string field, tuple_len)))
-            in
-            let span = Span.of_thir e.span in
-            App
-              {
-                f = { e = projector; typ = TArrow ([ lhs.typ ], typ); span };
-                args = [ lhs ];
-              }
-        | GlobalName { id } -> GlobalVar (def_id Value id)
-        | UpvarRef { var_hir_id = id; _ } -> LocalVar (local_ident Expr id)
-        | Borrow { arg; borrow_kind = kind } ->
-            let e' = c_expr arg in
-            let kind = c_borrow_kind e.span kind in
-            Borrow { kind; e = e'; witness = W.reference }
-        | AddressOf { arg; mutability = mut } ->
-            let e = c_expr arg in
-            AddressOf
-              {
-                e;
-                mut = c_mutability W.mutable_pointer mut;
-                witness = W.raw_pointer;
-              }
-        | Break { value; _ } ->
-            (* TODO: labels! *)
-            let e = Option.map ~f:c_expr value in
-            let e = Option.value ~default:(unit_expr span) e in
-            Break { e; label = None; witness = (W.break, W.loop) }
-        | Continue _ ->
-            Continue { e = None; label = None; witness = (W.continue, W.loop) }
-        | Return { value } ->
-            let e = Option.map ~f:c_expr value in
-            let e = Option.value ~default:(unit_expr span) e in
-            Return { e; witness = W.early_exit }
-        | ConstBlock _ -> unimplemented [ e.span ] "ConstBlock"
-        | ConstParam { param = id; _ } (* TODO: shadowing? *) | ConstRef { id }
-          ->
-            LocalVar
-              {
-                name = id.name;
-                id = LocalIdent.mk_id Cnst (MyInt64.to_int_exn id.index);
-              }
-        | Repeat { value; count } ->
-            let value = c_expr value in
-            let count = c_constant_expr count in
-            let inner =
-              U.call Rust_primitives__hax__repeat [ value; count ] span typ
-            in
-            (U.call Alloc__boxed__Impl__new [ inner ] span typ).e
-        | Tuple { fields } ->
-            (U.make_tuple_expr' ~span @@ List.map ~f:c_expr fields).e
-        | Array { fields } -> Array (List.map ~f:c_expr fields)
-        | Adt { info; base; fields; _ } ->
-            let constructor =
-              def_id
-                (Constructor { is_struct = info.typ_is_struct })
-                info.variant
-            in
-            let base =
-              Option.map
-                ~f:(fun base -> (c_expr base.base, W.construct_base))
-                base
-            in
-            let fields =
-              List.map
-                ~f:(fun f ->
-                  let field = def_id Field f.field in
-                  let value = c_expr f.value in
-                  (field, value))
-                fields
-            in
-            Construct
-              {
-                is_record = info.variant_is_record;
-                is_struct = info.typ_is_struct;
-                constructor;
-                fields;
-                base;
-              }
-        | Literal { lit; neg; _ } -> (
-            match c_lit e.span neg lit typ with
-            | EL_Lit lit -> Literal lit
-            | EL_U8Array l ->
-                Array
-                  (List.map
-                     ~f:(fun lit ->
-                       {
-                         e = Literal lit;
-                         span;
-                         typ = TInt { size = S8; signedness = Unsigned };
-                       })
-                     l))
-        | NamedConst { def_id = id; _ } -> GlobalVar (def_id Value id)
-        | Closure { body; params; upvars; _ } ->
-            let params =
-              List.filter_map ~f:(fun p -> Option.map ~f:c_pat p.pat) params
-            in
-            let body = c_expr body in
-            let upvars = List.map ~f:c_expr upvars in
-            Closure { body; params; captures = upvars }
-        | Index { index; lhs } ->
-            let index_type = c_ty index.span index.ty in
-            let lhs_type = c_ty lhs.span lhs.ty in
-            call
-              (mk_global ([ lhs_type; index_type ] ->. typ)
-              @@ Global_ident.of_name Value Core__ops__index__Index__index)
-              [ lhs; index ]
-        | StaticRef { def_id = id; _ } -> GlobalVar (def_id Value id)
-        | PlaceTypeAscription _ ->
-            unimplemented [ e.span ] "expression PlaceTypeAscription"
-        | ValueTypeAscription _ ->
-            unimplemented [ e.span ] "expression ValueTypeAscription"
-        | ZstLiteral _ -> unimplemented [ e.span ] "expression ZstLiteral"
-        | Yield _ -> unimplemented [ e.span ] "expression Yield"
-        | Todo payload ->
-            unimplemented [ e.span ] ("expression Todo\n" ^ payload)
-      in
-      { e = v; span; typ }
-
-    and c_lhs lhs =
-      match lhs.e with
-      | LocalVar var -> LhsLocalVar { var; typ = lhs.typ }
-      | _ -> (
-          match resugar_index_mut lhs with
-          | Some (e, index) ->
-              LhsArrayAccessor
-                {
-                  e = c_lhs e;
-                  typ = lhs.typ;
-                  index;
-                  witness = W.nontrivial_lhs;
-                }
-          | None -> (
-              match (U.unbox_underef_expr lhs).e with
-              | App
-                  {
-                    f =
-                      {
-                        e = GlobalVar (`Projector _ as field);
-                        typ = TArrow ([ _ ], _);
-                        span = _;
-                      };
-                    args = [ e ];
-                  } ->
-                  LhsFieldAccessor
-                    {
-                      e = c_lhs e;
-                      typ = lhs.typ;
-                      field;
-                      witness = W.nontrivial_lhs;
-                    }
-              | _ -> LhsArbitraryExpr { e = lhs; witness = W.arbitrary_lhs }))
-
-    and c_expr_assign lhs rhs =
-      Assign { lhs = c_lhs lhs; e = rhs; witness = W.mutable_variable }
-
-    and c_constant_expr (ce : Thir.decorated_for__constant_expr_kind) : expr =
-      let rec constant_expr_to_expr
-          (ce : Thir.decorated_for__constant_expr_kind) :
-          Thir.decorated_for__expr_kind =
-        {
-          attributes = ce.attributes;
-          contents = constant_expr_kind_to_expr_kind ce.contents ce.span;
-          hir_id = ce.hir_id;
-          span = ce.span;
-          ty = ce.ty;
-        }
-      and constant_expr_kind_to_expr_kind (ce : Thir.constant_expr_kind) span :
-          Thir.expr_kind =
-        match ce with
-        | Literal lit ->
-            let lit, neg = constant_lit_to_lit lit in
-            Literal { lit = { node = lit; span }; neg }
-        | Adt { fields; info } ->
-            let fields = List.map ~f:constant_field_expr fields in
-            Adt { fields; info; base = None; user_ty = None }
-        | Array { fields } ->
-            Array { fields = List.map ~f:constant_expr_to_expr fields }
-        | Tuple { fields } ->
-            Tuple { fields = List.map ~f:constant_expr_to_expr fields }
-        | GlobalName { id } -> GlobalName { id }
-        | Borrow arg ->
-            Borrow
-              { arg = constant_expr_to_expr arg; borrow_kind = Thir.Shared }
-        | ConstRef { id } -> ConstRef { id }
-        | Todo _ -> unimplemented [ span ] "ConstantExpr::Todo"
-      and constant_lit_to_lit (l : Thir.constant_literal) : Thir.lit_kind * bool
-          =
-        match l with
-        | Bool v -> (Bool v, false)
-        | Char v -> (Char v, false)
-        | Int (Int (v, ty)) -> (
-            match String.chop_prefix v ~prefix:"-" with
-            | Some v -> (Int (v, Signed ty), true)
-            | None -> (Int (v, Signed ty), false))
-        | Int (Uint (v, ty)) -> (Int (v, Unsigned ty), false)
-        | ByteStr (v, style) -> (ByteStr (v, style), false)
-      and constant_field_expr ({ field; value } : Thir.constant_field_expr) :
-          Thir.field_expr =
-        { field; value = constant_expr_to_expr value }
-      in
-      c_expr (constant_expr_to_expr ce)
-
-    and c_pat (pat : Thir.decorated_for__pat_kind) : pat =
-      let span = Span.of_thir pat.span in
-      let typ = c_ty pat.span pat.ty in
-      let v =
-        match pat.contents with
-        | Wild -> PWild
-        | AscribeUserType { ascription = { annotation; _ }; subpattern } ->
-            let typ, typ_span = c_canonical_user_type_annotation annotation in
-            let pat = c_pat subpattern in
-            PAscription { typ; typ_span; pat }
-        | Binding { mode; mutability; subpattern; ty; var; _ } ->
-            let mut = c_mutability W.mutable_variable mutability in
-            let subpat =
-              Option.map ~f:(c_pat &&& Fn.const W.as_pattern) subpattern
-            in
-            let typ = c_ty pat.span ty in
-            let mode = c_binding_mode pat.span mode in
-            let var = local_ident Expr var in
-            PBinding { mut; mode; var; typ; subpat }
-        | Variant { info; subpatterns; _ } ->
-            let name =
-              def_id
-                (Constructor { is_struct = info.typ_is_struct })
-                info.variant
-            in
-            let args = List.map ~f:(c_field_pat info) subpatterns in
-            PConstruct
-              {
-                name;
-                args;
-                is_record = info.variant_is_record;
-                is_struct = info.typ_is_struct;
-              }
-        | Tuple { subpatterns } ->
-            (List.map ~f:c_pat subpatterns |> U.make_tuple_pat').p
-        | Deref { subpattern } ->
-            PDeref { subpat = c_pat subpattern; witness = W.reference }
-        | Constant { value } ->
-            let rec pat_of_expr (e : expr) =
-              { p = pat'_of_expr' e.e e.span; span = e.span; typ = e.typ }
-            and pat'_of_expr' (e : expr') span =
-              match e with
-              | Literal lit -> PConstant { lit }
-              | Array l -> PArray { args = List.map ~f:pat_of_expr l }
-              | Borrow { kind = _; e; witness } ->
-                  PDeref { subpat = pat_of_expr e; witness }
-              | _ ->
-                  assertion_failure (Span.to_thir span)
-                    ("expected a pattern, got " ^ [%show: expr'] e)
-            in
-            (c_constant_expr value |> pat_of_expr).p
-        | Array _ -> unimplemented [ pat.span ] "Pat:Array"
-        | Or _ ->
-            unimplemented [ pat.span ] ~issue_id:161
-              "Or patterns (see \
-               https://rust-lang.github.io/rfcs/2535-or-patterns.html)"
-        | Slice _ -> unimplemented [ pat.span ] "pat Slice"
-        | Range _ -> unimplemented [ pat.span ] "pat Range"
-      in
-      { p = v; span; typ }
-
-    and c_field_pat _info (field_pat : Thir.field_pat) : field_pat =
-      { field = def_id Field field_pat.field; pat = c_pat field_pat.pattern }
-
-    and extended_literal_of_expr (e : expr) : extended_literal =
-      let not_a_literal () =
-        assertion_failure (Span.to_thir e.span)
-          ("expected a literal, got " ^ [%show: expr] e)
-      in
-      match e.e with
-      | Literal lit -> EL_Lit lit
-      | Array lits ->
-          EL_U8Array
-            (List.map
-               ~f:(function
-                 | {
-                     e =
-                       Literal
-                         (Int { kind = { size = S8; signedness = Unsigned }; _ }
-                         as lit);
-                     _;
-                   } ->
-                     lit
-                 | _ -> not_a_literal ())
-               lits)
-      | _ -> not_a_literal ()
-
-    and c_canonical_user_type_annotation
-        (annotation : Thir.canonical_user_type_annotation) : ty * span =
-      (c_ty annotation.span annotation.inferred_ty, Span.of_thir annotation.span)
-
-    and c_pointer e typ span cast source =
-      match cast with
-      | ReifyFnPointer ->
-          (* we have arrow types, we do not distinguish between top-level functions and closures *)
-          (c_expr source).e
-      | Unsize ->
-          (* https://doc.rust-lang.org/std/marker/trait.Unsize.html *)
-          (U.call Rust_primitives__unsize [ c_expr source ] span typ).e
-          (* let source = c_expr source in *)
-          (* let from_typ = source.typ in *)
-          (* let to_typ = typ in *)
-          (* match (U.Box.Ty.destruct from_typ, U.Box.Ty.destruct to_typ) with *)
-          (* | Some _from_typ, Some to_typ -> ( *)
-          (*     match U.Box.Expr.destruct source with *)
-          (*     | Some source -> *)
-          (*         (U.Box.Expr.make *)
-          (*         @@ U.call "dummy" "unsize_cast" [] [ source ] span to_typ) *)
-          (*           .e *)
-          (*     | _ -> *)
-          (*         unimplemented e.span *)
-          (*           "[Pointer(Unsize)] cast from not directly boxed expression") *)
-          (* | _ -> *)
-          (*     unimplemented e.span *)
-          (*       ("[Pointer(Unsize)] cast\n • from type [" *)
-          (*       ^ [%show: ty] from_typ *)
-          (*       ^ "]\n • to type [" *)
-          (*       ^ [%show: ty] to_typ *)
-          (*       ^ "]\n\nThe expression is: " *)
-          (*       ^ [%show: expr] source)) *)
-      | _ ->
-          unimplemented [ e.span ]
-            ("Pointer, with [cast] being " ^ [%show: Thir.pointer_cast] cast)
-
-    and c_ty (span : Thir.span) (ty : Thir.ty) : ty =
-      match ty with
-      | Bool -> TBool
-      | Char -> TChar
-      | Int k -> TInt (c_int_ty k)
-      | Uint k -> TInt (c_uint_ty k)
-      | Float k -> TFloat (match k with F32 -> F32 | F64 -> F64)
-      | Arrow value ->
-          let ({ inputs; output; _ } : Thir.ty_fn_sig) = value.value in
-          TArrow (List.map ~f:(c_ty span) inputs, c_ty span output)
-      | Adt { def_id = id; generic_args } ->
-          let ident = def_id Type id in
-          let args = List.map ~f:(c_generic_value span) generic_args in
-          TApp { ident; args }
-      | Foreign _ -> unimplemented [ span ] "Foreign"
-      | Str -> TStr
-      | Array (ty, len) ->
-          TArray { typ = c_ty span ty; length = c_constant_expr len }
-      | Slice ty ->
-          let ty = c_ty span ty in
-          TSlice { ty; witness = W.slice }
-      | RawPtr _ -> TRawPointer { witness = W.raw_pointer }
-      | Ref (_region, ty, mut) ->
-          let typ = c_ty span ty in
-          let mut = c_mutability W.mutable_reference mut in
-          TRef { witness = W.reference; region = "todo"; typ; mut }
-      | Never -> U.never_typ
-      | Tuple types ->
-          let types = List.map ~f:(fun ty -> GType (c_ty span ty)) types in
-          TApp { ident = `TupleType (List.length types); args = types }
-      | Alias (_kind, { trait_def_id = Some (_did, impl_expr); def_id; _ }) ->
-          let impl = c_impl_expr span impl_expr in
-          let item = Concrete_ident.of_def_id (AssociatedItem Type) def_id in
-          TAssociatedType { impl; item }
-      | Alias (_kind, { def_id; trait_def_id = None; _ }) ->
-          TOpaque (Concrete_ident.of_def_id Type def_id)
-      | Param { index; name } ->
-          (* TODO: [id] might not unique *)
-          TParam { name; id = LocalIdent.mk_id Typ (MyInt64.to_int_exn index) }
-      | Error -> unimplemented [ span ] "type Error"
-      | Dynamic _ -> unimplemented [ span ] "type Dynamic"
-      | Generator _ -> unimplemented [ span ] "type Generator"
-      | Placeholder _ -> unimplemented [ span ] "type Placeholder"
-      | Bound _ -> unimplemented [ span ] "type Bound"
-      | Infer _ -> unimplemented [ span ] "type Infer"
-      | Todo _ -> unimplemented [ span ] "type Todo"
-    (* fun _ -> Ok Bool *)
-
-    and c_impl_expr (span : Thir.span) (ie : Thir.impl_expr) : impl_expr =
-      let impl = c_impl_expr_atom span ie.impl in
-      match ie.args with
-      | [] -> impl
-      | args ->
-          let args = List.map ~f:(c_impl_expr span) args in
-          ImplApp { impl; args }
-
-    and c_impl_expr_atom (span : Thir.span) (ie : Thir.impl_expr_atom) :
-        impl_expr =
-      let c_trait_ref (tr : Thir.trait_ref) : trait_ref =
-        let trait = Concrete_ident.of_def_id Trait tr.def_id in
-        let args = List.map ~f:(c_generic_value span) tr.generic_args in
-        { trait; args }
-      in
-      match ie with
-      | Concrete { id; generics } ->
-          let trait = Concrete_ident.of_def_id Trait id in
-          let args = List.map ~f:(c_generic_value span) generics in
-          Concrete { trait; args }
-      | LocalBound { clause_id; path } ->
-          let init = LocalBound { id = clause_id } in
-          let f (impl : impl_expr) (chunk : Thir.impl_expr_path_chunk) =
-            match chunk with
-            | AssocItem (item, { trait_ref; _ }) ->
-                let trait = c_trait_ref trait_ref in
-                let kind : Concrete_ident.Kind.t =
-                  match item.kind with Const | Fn -> Value | Type -> Type
-                in
-                let item = Concrete_ident.of_def_id kind item.def_id in
-                Projection { impl; trait; item }
-            | Parent { trait_ref; _ } ->
-                let trait = c_trait_ref trait_ref in
-                Parent { impl; trait }
-          in
-          List.fold ~init ~f path
-      | Dyn { trait } -> Dyn (c_trait_ref trait)
-      | Builtin { trait } -> Builtin (c_trait_ref trait)
-      | Todo str -> failwith @@ "impl_expr_atom: Todo " ^ str
-
-    and c_generic_value (span : Thir.span) (ty : Thir.generic_arg) :
-        generic_value =
-      match ty with
-      | Type ty -> GType (c_ty span ty)
-      | Const e -> GConst (c_constant_expr e)
-      | _ -> GLifetime { lt = "todo generics"; witness = W.lifetime }
-
-    and c_arm (arm : Thir.arm) : arm =
-      let arm_pat = c_pat arm.pattern in
-      let body = c_expr arm.body in
-      let span = Span.of_thir arm.span in
-      { arm = { arm_pat; body }; span }
-
-    and c_param span (param : Thir.param) : param =
-      {
-        typ_span = Option.map ~f:Span.of_thir param.ty_span;
-        typ = c_ty (Option.value ~default:span param.ty_span) param.ty;
-        pat = c_pat (Option.value_exn param.pat);
-        attrs = c_attrs param.attributes;
-      }
-
-    let c_generic_param (param : Thir.generic_param) : generic_param =
-      let ident =
+        let tokens =
+          let ( || ) = Option.first_some in
+          Option.value ~default:"" (args_tokens || tokens || subtokens)
+        in
+        Tool { path; tokens }
+    | DocComment (kind, body) ->
         let kind =
-          match (param.kind : Thir.generic_param_kind) with
-          | Lifetime _ -> LocalIdent.LILifetime
-          | Type _ -> LocalIdent.Typ
-          | Const _ -> LocalIdent.Cnst
+          match kind with Thir.Line -> DCKLine | Thir.Block -> DCKBlock
         in
-        match param.name with
-        | Fresh ->
-            (* fail with ("[Fresh] ident? " ^ Thir.show_generic_param param) *)
-            (* TODO might be wrong to just have a wildcard here *)
-            ({ name = "_"; id = LocalIdent.mk_id kind 123 } : local_ident)
-        | Error -> assertion_failure [ param.span ] "[Error] ident"
-        | Plain n -> local_ident kind n
-      in
-      let kind =
-        match (param.kind : Thir.generic_param_kind) with
-        | Lifetime _ -> GPLifetime { witness = W.lifetime }
-        | Type { default; _ } ->
-            let default = Option.map ~f:(c_ty param.span) default in
-            GPType { default }
-        | Const { default = Some _; _ } ->
-            unimplemented [ param.span ] "c_generic_param:Const with a default"
-        | Const { default = None; ty } -> GPConst { typ = c_ty param.span ty }
-      in
-      let span = Span.of_thir param.span in
-      let attrs = c_attrs param.attributes in
-      { ident; span; attrs; kind }
+        DocComment { kind; body }
+  in
+  { kind; span = Span.of_thir attr.span }
 
-    let c_predicate_kind' span (p : Thir.predicate_kind) :
-        (trait_ref * string) option =
-      match p with
-      | Clause
-          { kind = Trait { is_positive = true; is_const = _; trait_ref }; id }
-        ->
-          let args =
-            List.map ~f:(c_generic_value span) trait_ref.generic_args
-          in
-          let trait = Concrete_ident.of_def_id Trait trait_ref.def_id in
-          Some ({ trait; args }, id)
-      | _ -> None
+let c_attrs : Thir.attribute list -> attrs = List.map ~f:c_attr
 
-    let c_predicate_kind span (p : Thir.predicate_kind) : trait_ref option =
-      c_predicate_kind' span p |> Option.map ~f:fst
+let c_item_attrs (attrs : Thir.item_attributes) : attrs =
+  (* TODO: This is a quite coarse approximation, we need to reflect
+     that parent/self structure in our AST. *)
+  c_attrs (attrs.parent_attributes @ attrs.attributes)
 
-    let list_dedup (equal : 'a -> 'a -> bool) : 'a list -> 'a list =
-      let rec aux (seen : 'a list) (todo : 'a list) : 'a list =
-        match todo with
-        | hd :: tl ->
-            if List.mem ~equal seen hd then aux seen tl
-            else hd :: aux (hd :: seen) tl
-        | _ -> todo
-      in
-      aux []
+type extended_literal =
+  | EL_Lit of literal
+  | EL_U8Array of literal list (* EL_U8Array only encodes arrays of [u8]s *)
 
-    let c_generics (generics : Thir.generics) : generics =
-      let bounds =
-        List.filter_map ~f:(c_predicate_kind' generics.span) generics.bounds
-        |> List.map ~f:(fun (trait, id) : generic_constraint ->
-               GCType { bound = trait; id })
-      in
+let c_lit' span negative (lit : Thir.lit_kind) (ty : ty) : extended_literal =
+  let mk l = EL_Lit l in
+  let mku8 (n : int) =
+    let kind = { size = S8; signedness = Unsigned } in
+    Int { value = Int.to_string n; kind; negative = false }
+  in
+  let error kind =
+    assertion_failure [ span ]
+      ("[import_thir:literal] got a " ^ kind ^ " literal, expected " ^ kind
+     ^ " type, got type ["
+      ^ [%show: ty] ty
+      ^ "] instead.")
+  in
+  match lit with
+  | Err ->
+      assertion_failure [ span ]
+        "[import_thir:literal] got an error literal: this means the Rust \
+         compiler or Hax's frontend probably reported errors above."
+  | Str (str, _) -> mk @@ String str
+  | CStr (l, _) | ByteStr (l, _) -> EL_U8Array (List.map ~f:mku8 l)
+  | Byte n -> mk @@ mku8 n
+  | Char s -> mk @@ Char s
+  | Int (value, _kind) ->
+      mk
+      @@ Int
+           {
+             value;
+             negative;
+             kind = (match ty with TInt k -> k | _ -> error "integer");
+           }
+  | Float (value, _kind) ->
+      mk
+      @@ Float
+           {
+             value;
+             negative;
+             kind = (match ty with TFloat k -> k | _ -> error "float");
+           }
+  | Bool b -> mk @@ Bool b
+
+let c_lit span neg (lit : Thir.spanned_for__lit_kind) : ty -> extended_literal =
+  c_lit' span neg lit.node
+
+let resugar_index_mut (e : expr) : (expr * expr) option =
+  match (U.unbox_underef_expr e).e with
+  | App
       {
-        params = List.map ~f:c_generic_param generics.params;
-        constraints = bounds |> list_dedup equal_generic_constraint;
+        f = { e = GlobalVar (`Concrete meth); _ };
+        args = [ { e = Borrow { e = x; _ }; _ }; index ];
       }
+    when Concrete_ident.eq_name Core__ops__index__IndexMut__index_mut meth ->
+      Some (x, index)
+  | App { f = { e = GlobalVar (`Concrete meth); _ }; args = [ x; index ] }
+    when Concrete_ident.eq_name Core__ops__index__Index__index meth ->
+      Some (x, index)
+  | _ -> None
 
-    let c_trait_item' (super : Thir.trait_item) (item : Thir.trait_item_kind) :
-        trait_item' =
-      let span = super.span in
-      match item with
-      | Const (_, Some _) ->
-          unimplemented [ span ]
-            "TODO: traits: no support for defaults in traits for now"
-      | Const (ty, None) -> TIFn (c_ty span ty)
-      | ProvidedFn (sg, _) | RequiredFn (sg, _) ->
-          let (Thir.{ inputs; output; _ } : Thir.fn_decl) = sg.decl in
-          let output =
-            match output with
-            | DefaultReturn _span -> unit_typ
-            | Return ty -> c_ty span ty
-          in
-          TIFn (TArrow (List.map ~f:(c_ty span) inputs, output))
-      | Type (bounds, None) ->
-          let bounds = List.filter_map ~f:(c_predicate_kind span) bounds in
-          TIType bounds
-      | Type (_, Some _) ->
-          unimplemented [ span ]
-            "TODO: traits: no support for defaults in type for now"
-  end
+module type EXPR = sig
+  val c_expr : Thir.decorated_for__expr_kind -> expr
+  val c_ty : Thir.span -> Thir.ty -> ty
+  val c_generic_value : Thir.span -> Thir.generic_arg -> generic_value
+  val c_generics : Thir.generics -> generics
+  val c_param : Thir.span -> Thir.param -> param
+  val c_trait_item' : Thir.trait_item -> Thir.trait_item_kind -> trait_item'
+end
 
-  let make ~krate : (module EXPR) =
-    let is_core_item = String.(krate = "core" || krate = "core_hax_model") in
-    let module M : EXPR = Make (struct
-      let is_core_item = is_core_item
-    end) in
-    (module M)
+(* BinOp to [core::ops::*] overloaded functions *)
 
-  let c_trait_item (item : Thir.trait_item) : trait_item =
-    let open (val make ~krate:item.owner_id.krate : EXPR) in
-    let { params; constraints } = c_generics item.generics in
-    (* TODO: see TODO in impl items *)
-    let ti_ident = Concrete_ident.of_def_id Field item.owner_id in
-    {
-      ti_span = Span.of_thir item.span;
-      ti_generics = { params; constraints };
-      ti_v = c_trait_item' item item.kind;
-      ti_ident;
-      ti_attrs = c_item_attrs item.attributes;
-    }
+module Make (CTX : sig
+  val is_core_item : bool
+end) : EXPR = struct
+  let c_binop (op : Thir.bin_op) (lhs : expr) (rhs : expr) (span : span)
+      (typ : ty) =
+    let overloaded_names_of_binop : Thir.bin_op -> Concrete_ident.name =
+      function
+      | Add -> Core__ops__arith__Add__add
+      | Sub -> Core__ops__arith__Sub__sub
+      | Mul -> Core__ops__arith__Mul__mul
+      | Div -> Core__ops__arith__Div__div
+      | Rem -> Core__ops__arith__Rem__rem
+      | BitXor -> Core__ops__bit__BitXor__bitxor
+      | BitAnd -> Core__ops__bit__BitAnd__bitand
+      | BitOr -> Core__ops__bit__BitOr__bitor
+      | Shl -> Core__ops__bit__Shl__shl
+      | Shr -> Core__ops__bit__Shr__shr
+      | Lt -> Core__cmp__PartialOrd__lt
+      | Le -> Core__cmp__PartialOrd__le
+      | Ne -> Core__cmp__PartialEq__ne
+      | Ge -> Core__cmp__PartialOrd__ge
+      | Gt -> Core__cmp__PartialOrd__gt
+      | Eq -> Core__cmp__PartialEq__eq
+      | Offset -> Core__ptr__const_ptr__Impl__offset
+    in
+    let primitive_names_of_binop : Thir.bin_op -> Concrete_ident.name = function
+      | Add -> Rust_primitives__u128__add
+      | Sub -> Rust_primitives__u128__sub
+      | Mul -> Rust_primitives__u128__mul
+      | Div -> Rust_primitives__u128__div
+      | Rem -> Rust_primitives__u128__rem
+      | BitXor -> Rust_primitives__u128__bit_xor
+      | BitAnd -> Rust_primitives__u128__bit_and
+      | BitOr -> Rust_primitives__u128__bit_or
+      | Shl -> Rust_primitives__u128__shl
+      | Shr -> Rust_primitives__u128__shr
+      | Lt -> Rust_primitives__u128__lt
+      | Le -> Rust_primitives__u128__le
+      | Ne -> Rust_primitives__u128__ne
+      | Ge -> Rust_primitives__u128__ge
+      | Gt -> Rust_primitives__u128__gt
+      | Eq -> Rust_primitives__u128__eq
+      | Offset -> Rust_primitives__offset
+    in
+    let name =
+      if CTX.is_core_item then
+        let assert_type_eq t1 t2 =
+          if not (U.ty_equality t1 t2) then
+            assertion_failure (Span.to_thir span)
+              ("Binary operation: expected LHS and RHS to have the same type, \
+                instead LHS has type ["
+              ^ [%show: ty] t1
+              ^ "] while RHS has type ["
+              ^ [%show: ty] t2
+              ^ "]")
+        in
+        let int =
+          ("int", function TInt k -> Some (show_int_kind k) | _ -> None)
+        in
+        let float =
+          ("float", function TFloat k -> Some (show_float_kind k) | _ -> None)
+        in
+        let bool = ("bool", function TBool -> Some "bool" | _ -> None) in
+        let concat_tup sep (x, y) = x ^ sep ^ y in
+        let ( <*> ) (x, f) (y, g) =
+          ( x ^ "*" ^ y,
+            f *** g >> uncurry Option.both >> Option.map ~f:(concat_tup "_") )
+        in
+        let both (e, f) =
+          ( e ^ "*" ^ e,
+            fun (t1, t2) ->
+              assert_type_eq t1 t2;
+              f t1 )
+        in
+        let ( <|> ) (x, f) (y, g) =
+          (x ^ " or" ^ y, fun v -> match f v with None -> g v | v -> v)
+        in
+        let name = primitive_names_of_binop op in
+        let expected, f =
+          match op with
+          | Add | Sub | Mul | Div -> both int <|> both float
+          | Rem -> both int
+          | BitXor | BitAnd | BitOr -> both int <|> both bool
+          | Shl | Shr -> int <*> int
+          | Lt | Le | Ne | Ge | Gt -> both int <|> both float
+          | Eq -> both int <|> both float <|> both bool
+          | Offset -> ("", fun _ -> Some "")
+        in
+        match f (lhs.typ, rhs.typ) with
+        | Some with_ ->
+            Concrete_ident.of_name Value name
+            |> Concrete_ident.map_path_strings ~f:(function
+                 | "u128" -> with_
+                 | s -> s)
+        | None ->
+            assertion_failure (Span.to_thir span)
+              ("Binary operation: expected " ^ expected ^ " type, got "
+              ^ [%show: ty] lhs.typ)
+      else Concrete_ident.of_name Value @@ overloaded_names_of_binop op
+    in
+    U.call' (`Concrete name) [ lhs; rhs ] span typ
 
-  let is_automatically_derived (attrs : Thir.attribute list) =
-    List.exists (* We need something better here, see issue #108 *)
-      ~f:(function
-        | { kind = Normal { item = { path; _ }; _ }; _ } ->
-            String.equal path "automatically_derived"
-        | _ -> false)
-      attrs
-
-  let is_hax_skip (attrs : Thir.attribute list) =
-    List.exists
-      ~f:(function
-        | { kind = Normal { item = { path; _ }; _ }; _ } ->
-            String.equal path "_hax::skip"
-        | _ -> false)
-      attrs
-
-  let should_skip (attrs : Thir.item_attributes) did =
-    let attrs = attrs.attributes @ attrs.parent_attributes in
-    is_hax_skip attrs
-    || is_automatically_derived attrs
-    || [%matches? (Types.Excluded : Types.inclusion_kind)]
-         (included_inclusion_clauses did)
-
-  let rec c_item (item : Thir.item) : item list =
-    try c_item_unwrapped item with Diagnostics.SpanFreeError.Exn _kind -> []
-
-  and c_item_unwrapped (item : Thir.item) : item list =
-    let open (val make ~krate:item.owner_id.krate : EXPR) in
-    let ident = Concrete_ident.of_def_id Value item.owner_id in
-    if should_skip item.attributes ident then []
-    else
-      let span = Span.of_thir item.span in
-      let mk_one v =
-        let attrs = c_item_attrs item.attributes in
-        { span; v; ident; attrs }
+  let rec c_expr (e : Thir.decorated_for__expr_kind) : expr =
+    try c_expr_unwrapped e
+    with Diagnostics.SpanFreeError.Exn (Data (ctx, kind)) ->
+      let typ : ty =
+        try c_ty e.span e.ty
+        with Diagnostics.SpanFreeError.Exn _ -> U.hax_failure_typ
       in
-      let mk v = [ mk_one v ] in
-      (* TODO: things might be unnamed (e.g. constants) *)
-      match (item.kind : Thir.item_kind) with
-      | Const (_, body) ->
-          mk
-          @@ Fn
-               {
-                 name =
-                   Concrete_ident.of_def_id Value (Option.value_exn item.def_id);
-                 generics = { params = []; constraints = [] };
-                 body = c_expr body;
-                 params = [];
-               }
-      | TyAlias (ty, generics) ->
-          mk
-          @@ TyAlias
-               {
-                 name =
-                   Concrete_ident.of_def_id Type (Option.value_exn item.def_id);
-                 generics = c_generics generics;
-                 ty = c_ty item.span ty;
-               }
-      | Fn (generics, { body; params; _ }) ->
-          mk
-          @@ Fn
-               {
-                 name =
-                   Concrete_ident.of_def_id Value (Option.value_exn item.def_id);
-                 generics = c_generics generics;
-                 body = c_expr body;
-                 params = List.map ~f:(c_param item.span) params;
-               }
-      | Enum (variants, generics) ->
-          let def_id = Option.value_exn item.def_id in
-          let generics = c_generics generics in
-          let is_struct = false in
-          let variants =
-            let kind = Concrete_ident.Kind.Constructor { is_struct } in
-            List.map
-              ~f:(fun { data; def_id = variant_id; attributes; _ } ->
-                let is_record = [%matches? Types.Struct (_ :: _, _)] data in
-                let name = Concrete_ident.of_def_id kind variant_id in
-                let arguments =
-                  match data with
-                  | Tuple (fields, _, _) | Struct (fields, _) ->
-                      List.map
-                        ~f:(fun { def_id = id; ty; span; attributes; _ } ->
-                          ( Concrete_ident.of_def_id Field id,
-                            c_ty span ty,
-                            c_attrs attributes ))
-                        fields
-                  | Unit _ -> []
-                in
-                let attrs = c_attrs attributes in
-                { name; arguments; is_record; attrs })
-              variants
-          in
-          let name = Concrete_ident.of_def_id Type def_id in
-          mk @@ Type { name; generics; variants; is_struct }
-      | Struct (v, generics) ->
-          let generics = c_generics generics in
-          let def_id = Option.value_exn item.def_id in
-          let is_struct = true in
-          (* repeating the attributes of the item in the variant: TODO is that ok? *)
-          let attrs = c_item_attrs item.attributes in
-          let v =
-            let kind = Concrete_ident.Kind.Constructor { is_struct } in
-            let name = Concrete_ident.of_def_id kind def_id in
-            let mk fields is_record =
-              let arguments =
-                List.map
-                  ~f:(fun Thir.{ def_id = id; ty; span; attributes; _ } ->
-                    ( Concrete_ident.of_def_id Field id,
-                      c_ty span ty,
-                      c_attrs attributes ))
-                  fields
-              in
-              { name; arguments; is_record; attrs }
-            in
-            match v with
-            | Tuple (fields, _, _) -> mk fields false
-            | Struct ((_ :: _ as fields), _) -> mk fields true
-            | _ -> { name; arguments = []; is_record = false; attrs }
-          in
-          let variants = [ v ] in
-          let name = Concrete_ident.of_def_id Type def_id in
-          mk @@ Type { name; generics; variants; is_struct }
-      | MacroInvokation { macro_ident; argument; span } ->
-          mk
-          @@ IMacroInvokation
-               {
-                 macro = Concrete_ident.of_def_id Macro macro_ident;
-                 argument;
-                 span = Span.of_thir span;
-                 witness = W.macro;
-               }
-      | Trait (No, Normal, generics, _bounds, items) ->
-          let items =
-            List.filter
-              ~f:(fun { attributes; owner_id; _ } ->
-                let did = Concrete_ident.of_def_id Value owner_id in
-                not (should_skip attributes did))
-              items
-          in
-          let name =
-            Concrete_ident.of_def_id Trait (Option.value_exn item.def_id)
-          in
-          let { params; constraints } = c_generics generics in
-          let self =
-            let id = LocalIdent.mk_id Typ 0 (* todo *) in
-            let ident = LocalIdent.{ name = "Self"; id } in
-            let kind = GPType { default = None } in
-            { ident; span; attrs = []; kind }
-          in
-          let params = self :: params in
-          let generics = { params; constraints } in
-          let items = List.map ~f:c_trait_item items in
-          mk @@ Trait { name; generics; items }
-      | Trait (Yes, _, _, _, _) -> unimplemented [ item.span ] "Auto trait"
-      | Trait (_, Unsafe, _, _, _) -> unimplemented [ item.span ] "Unsafe trait"
-      | Impl { of_trait = None; generics; items; _ } ->
-          let items =
-            List.filter
-              ~f:(fun { attributes; owner_id; _ } ->
-                let did = Concrete_ident.of_def_id Value owner_id in
-                not (should_skip attributes did))
-              items
-          in
-          List.map
-            ~f:(fun (item : Thir.impl_item) ->
-              let item_def_id = Concrete_ident.of_def_id Impl item.owner_id in
-              let v =
-                match (item.kind : Thir.impl_item_kind) with
-                | Fn { body; params; _ } ->
-                    Fn
-                      {
-                        name = item_def_id;
-                        generics = c_generics generics;
-                        body = c_expr body;
-                        params = List.map ~f:(c_param item.span) params;
-                      }
-                | Const (_ty, e) ->
-                    Fn
-                      {
-                        name = item_def_id;
-                        generics = c_generics generics;
-                        (* does that make sense? can we have `const<T>`? *)
-                        body = c_expr e;
-                        params = [];
-                      }
-                | Type _ty ->
-                    assertion_failure [ item.span ]
-                      "Inherent implementations are not supposed to have \
-                       associated types \
-                       (https://doc.rust-lang.org/reference/items/implementations.html#inherent-implementations)."
-              in
-              let ident = Concrete_ident.of_def_id Value item.owner_id in
-              let attrs = c_item_attrs item.attributes in
-              { span = Span.of_thir item.span; v; ident; attrs })
-            items
-      | Impl { unsafety = Unsafe; _ } -> unsafe_block [ item.span ]
-      | Impl
+      let span = Span.of_thir e.span in
+      U.hax_failure_expr' span typ (ctx, kind)
+        ([%show: Thir.decorated_for__expr_kind] e)
+
+  and c_expr_unwrapped (e : Thir.decorated_for__expr_kind) : expr =
+    let call f args = App { f; args = List.map ~f:c_expr args } in
+    let typ = c_ty e.span e.ty in
+    let span = Span.of_thir e.span in
+    let mk_global typ v : expr = { span; typ; e = GlobalVar v } in
+    let ( ->. ) a b = TArrow (a, b) in
+    let (v : expr') =
+      match e.contents with
+      | MacroInvokation { argument; macro_ident; _ } ->
+          MacroInvokation
+            {
+              args = argument;
+              macro = def_id Macro macro_ident;
+              witness = W.macro;
+            }
+      | If
           {
-            of_trait = Some of_trait;
-            generics;
-            self_ty;
-            items;
-            unsafety = Normal;
+            cond = { contents = Let { expr = scrutinee; pat }; _ };
+            else_opt;
+            then';
             _;
           } ->
-          let items =
-            List.filter
-              ~f:(fun { attributes; owner_id; _ } ->
-                let did = Concrete_ident.of_def_id Value owner_id in
-                not (should_skip attributes did))
-              items
+          let scrutinee = c_expr scrutinee in
+          let arm_pat = c_pat pat in
+          let then_ = c_expr then' in
+          let else_ =
+            Option.value ~default:(U.unit_expr span)
+            @@ Option.map ~f:c_expr else_opt
           in
-          mk
-          @@ Impl
-               {
-                 generics = c_generics generics;
-                 self_ty = c_ty item.span self_ty;
-                 of_trait =
-                   ( def_id Trait of_trait.def_id,
-                     List.map
-                       ~f:(c_generic_value item.span)
-                       of_trait.generic_args );
-                 items =
-                   List.map
-                     ~f:(fun (item : Thir.impl_item) ->
-                       (* TODO: introduce a Kind.TraitImplItem or
-                          something. Otherwise we have to assume every
-                          backend will see traits and impls as
-                          records. See https://github.com/hacspec/hacspec-v2/issues/271. *)
-                       let ii_ident =
-                         Concrete_ident.of_def_id Field item.owner_id
-                       in
-                       {
-                         ii_span = Span.of_thir item.span;
-                         ii_generics = c_generics item.generics;
-                         ii_v =
-                           (match (item.kind : Thir.impl_item_kind) with
-                           | Fn { body; params; _ } ->
-                               IIFn
-                                 {
-                                   body = c_expr body;
-                                   params =
-                                     List.map ~f:(c_param item.span) params;
-                                 }
-                           | Const (_ty, e) ->
-                               IIFn { body = c_expr e; params = [] }
-                           | Type ty -> IIType (c_ty item.span ty));
-                         ii_ident;
-                         ii_attrs = c_item_attrs item.attributes;
-                       })
-                     items;
-               }
-      | Use ({ span = _; res; segments; rename }, _) ->
-          let v =
-            Use
-              {
-                path = List.map ~f:(fun x -> fst x.ident) segments;
-                is_external =
-                  List.exists ~f:(function Err -> true | _ -> false) res;
-                (* TODO: this should represent local/external? *)
-                rename;
-              }
+          let arm_then =
+            { arm = { arm_pat; body = then_ }; span = then_.span }
           in
-          (* ident is supposed to always be an actual item, thus here we need to cheat a bit *)
-          (* TODO: is this DUMMY thing really needed? there's a `Use` segment (see #272) *)
-          let def_id = item.owner_id in
-          let def_id : Types.def_id =
+          let arm_else =
+            let arm_pat = { arm_pat with p = PWild } in
+            { arm = { arm_pat; body = else_ }; span = else_.span }
+          in
+          Match { scrutinee; arms = [ arm_then; arm_else ] }
+      | If { cond; else_opt; then'; _ } ->
+          let cond = c_expr cond in
+          let then_ = c_expr then' in
+          let else_ = Option.map ~f:c_expr else_opt in
+          If { cond; else_; then_ }
+      | Call { args; fn_span = _; impl; from_hir_call = _; fun'; ty = _ } ->
+          let args = List.map ~f:c_expr args in
+          let f =
+            let f = c_expr fun' in
+            match (impl, fun'.contents) with
+            | Some _, GlobalName { id } ->
+                { f with e = GlobalVar (def_id (AssociatedItem Value) id) }
+            | _ -> f
+          in
+          App { f; args }
+      | Box { value } ->
+          (U.call Rust_primitives__hax__box_new [ c_expr value ] span typ).e
+      | Deref { arg } ->
+          let inner_typ = c_ty arg.span arg.ty in
+          call (mk_global ([ inner_typ ] ->. typ) @@ `Primitive Deref) [ arg ]
+      | Binary { lhs; rhs; op } ->
+          (c_binop op (c_expr lhs) (c_expr rhs) span typ).e
+      | LogicalOp { lhs; rhs; op } ->
+          let lhs_type = c_ty lhs.span lhs.ty in
+          let rhs_type = c_ty rhs.span rhs.ty in
+          call
+            (mk_global ([ lhs_type; rhs_type ] ->. typ)
+            @@ `Primitive (LogicalOp (c_logical_op op)))
+            [ lhs; rhs ]
+      | Unary { arg; op } ->
+          (U.call
+             (match op with
+             | Not -> Core__ops__bit__Not__not
+             | Neg -> Core__ops__arith__Neg__neg)
+             [ c_expr arg ]
+             span typ)
+            .e
+      | Cast { source } ->
+          let source_type = c_ty source.span source.ty in
+          call
+            (mk_global ([ source_type ] ->. typ) @@ `Primitive Cast)
+            [ source ]
+      | Use { source } -> (c_expr source).e
+      | NeverToAny { source } ->
+          (U.call Rust_primitives__hax__never_to_any [ c_expr source ] span typ)
+            .e
+      (* TODO: this is incorrect (NeverToAny) *)
+      | Pointer { cast; source } -> c_pointer e typ span cast source
+      | Loop { body } ->
+          let body = c_expr body in
+          Loop
             {
-              def_id with
-              path =
-                def_id.path
-                @ [
-                    Types.
-                      {
-                        data = ValueNs "DUMMY";
-                        disambiguator = MyInt64.of_int 0;
-                      };
-                  ];
+              body;
+              kind = UnconditionalLoop;
+              state = None;
+              label = None;
+              witness = W.loop;
             }
+      | Match { scrutinee; arms } ->
+          let scrutinee = c_expr scrutinee in
+          let arms = List.map ~f:c_arm arms in
+          Match { scrutinee; arms }
+      | Let _ -> unimplemented [ e.span ] "Let"
+      | Block { safety_mode = BuiltinUnsafe | ExplicitUnsafe; _ } ->
+          unsafe_block [ e.span ]
+      | Block o ->
+          (* if there is no expression & the last expression is ⊥, just use that *)
+          let lift_last_statement_as_expr_if_possible expr stmts (ty : Thir.ty)
+              =
+            match (ty, expr, List.drop_last stmts, List.last stmts) with
+            | ( Thir.Never,
+                None,
+                Some stmts,
+                Some ({ kind = Thir.Expr { expr; _ }; _ } : Thir.stmt) ) ->
+                (stmts, Some expr)
+            | _ -> (stmts, expr)
           in
-          let attrs = c_item_attrs item.attributes in
-          [ { span; v; ident = Concrete_ident.of_def_id Value def_id; attrs } ]
-      | ExternCrate _ | Static _ | Macro _ | Mod _ | ForeignMod _ | GlobalAsm _
-      | OpaqueTy _ | Union _ | TraitAlias _ ->
-          mk NotImplementedYet
+          let o_stmts, o_expr =
+            lift_last_statement_as_expr_if_possible o.expr o.stmts e.ty
+          in
+          let init =
+            Option.map
+              ~f:(fun e ->
+                let e = c_expr e in
+                { e with e = Block (e, W.block) })
+              o_expr
+            |> Option.value ~default:(unit_expr span)
+          in
+          let { e; _ } =
+            List.fold_right o_stmts ~init ~f:(fun { kind; _ } body ->
+                match kind with
+                | Expr { expr = rhs; _ } ->
+                    let rhs = c_expr rhs in
+                    let e =
+                      Let
+                        {
+                          monadic = None;
+                          lhs = wild_pat rhs.span rhs.typ;
+                          rhs;
+                          body;
+                        }
+                    in
+                    { e; typ; span = Span.union rhs.span body.span }
+                | Let { else_block = Some _; _ } ->
+                    unimplemented ~issue_id:155 [ e.span ]
+                      "Sorry, Hax does not support [let-else] (see \
+                       https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) \
+                       for now."
+                | Let { initializer' = None; _ } ->
+                    unimplemented ~issue_id:156 [ e.span ]
+                      "Sorry, Hax does not support declare-first let bindings \
+                       (see \
+                       https://doc.rust-lang.org/rust-by-example/variable_bindings/declare.html) \
+                       for now."
+                | Let { pattern = lhs; initializer' = Some rhs; _ } ->
+                    let lhs = c_pat lhs in
+                    let rhs = c_expr rhs in
+                    let e = Let { monadic = None; lhs; rhs; body } in
+                    { e; typ; span = Span.union rhs.span body.span })
+          in
+          e
+      | Assign { lhs; rhs } ->
+          let lhs = c_expr lhs in
+          let rhs = c_expr rhs in
+          c_expr_assign lhs rhs
+      | AssignOp { lhs; op; rhs } ->
+          let lhs = c_expr lhs in
+          c_expr_assign lhs @@ c_binop op lhs (c_expr rhs) span typ
+      | VarRef { id } -> LocalVar (local_ident Expr id)
+      | Field { lhs; field } ->
+          let lhs = c_expr lhs in
+          let projector =
+            GlobalVar
+              (`Projector (`Concrete (Concrete_ident.of_def_id Field field)))
+          in
+          let span = Span.of_thir e.span in
+          App
+            {
+              f = { e = projector; typ = TArrow ([ lhs.typ ], typ); span };
+              args = [ lhs ];
+            }
+      | TupleField { lhs; field } ->
+          (* TODO: refactor *)
+          let tuple_len = 0 (* todo, lookup type *) in
+          let lhs = c_expr lhs in
+          let projector =
+            GlobalVar
+              (`Projector (`TupleField (Int.of_string field, tuple_len)))
+          in
+          let span = Span.of_thir e.span in
+          App
+            {
+              f = { e = projector; typ = TArrow ([ lhs.typ ], typ); span };
+              args = [ lhs ];
+            }
+      | GlobalName { id } -> GlobalVar (def_id Value id)
+      | UpvarRef { var_hir_id = id; _ } -> LocalVar (local_ident Expr id)
+      | Borrow { arg; borrow_kind = kind } ->
+          let e' = c_expr arg in
+          let kind = c_borrow_kind e.span kind in
+          Borrow { kind; e = e'; witness = W.reference }
+      | AddressOf { arg; mutability = mut } ->
+          let e = c_expr arg in
+          AddressOf
+            {
+              e;
+              mut = c_mutability W.mutable_pointer mut;
+              witness = W.raw_pointer;
+            }
+      | Break { value; _ } ->
+          (* TODO: labels! *)
+          let e = Option.map ~f:c_expr value in
+          let e = Option.value ~default:(unit_expr span) e in
+          Break { e; label = None; witness = (W.break, W.loop) }
+      | Continue _ ->
+          Continue { e = None; label = None; witness = (W.continue, W.loop) }
+      | Return { value } ->
+          let e = Option.map ~f:c_expr value in
+          let e = Option.value ~default:(unit_expr span) e in
+          Return { e; witness = W.early_exit }
+      | ConstBlock _ -> unimplemented [ e.span ] "ConstBlock"
+      | ConstParam { param = id; _ } (* TODO: shadowing? *) | ConstRef { id } ->
+          LocalVar
+            {
+              name = id.name;
+              id = LocalIdent.mk_id Cnst (MyInt64.to_int_exn id.index);
+            }
+      | Repeat { value; count } ->
+          let value = c_expr value in
+          let count = c_constant_expr count in
+          let inner =
+            U.call Rust_primitives__hax__repeat [ value; count ] span typ
+          in
+          (U.call Alloc__boxed__Impl__new [ inner ] span typ).e
+      | Tuple { fields } ->
+          (U.make_tuple_expr' ~span @@ List.map ~f:c_expr fields).e
+      | Array { fields } -> Array (List.map ~f:c_expr fields)
+      | Adt { info; base; fields; _ } ->
+          let constructor =
+            def_id (Constructor { is_struct = info.typ_is_struct }) info.variant
+          in
+          let base =
+            Option.map
+              ~f:(fun base -> (c_expr base.base, W.construct_base))
+              base
+          in
+          let fields =
+            List.map
+              ~f:(fun f ->
+                let field = def_id Field f.field in
+                let value = c_expr f.value in
+                (field, value))
+              fields
+          in
+          Construct
+            {
+              is_record = info.variant_is_record;
+              is_struct = info.typ_is_struct;
+              constructor;
+              fields;
+              base;
+            }
+      | Literal { lit; neg; _ } -> (
+          match c_lit e.span neg lit typ with
+          | EL_Lit lit -> Literal lit
+          | EL_U8Array l ->
+              Array
+                (List.map
+                   ~f:(fun lit ->
+                     {
+                       e = Literal lit;
+                       span;
+                       typ = TInt { size = S8; signedness = Unsigned };
+                     })
+                   l))
+      | NamedConst { def_id = id; _ } -> GlobalVar (def_id Value id)
+      | Closure { body; params; upvars; _ } ->
+          let params =
+            List.filter_map ~f:(fun p -> Option.map ~f:c_pat p.pat) params
+          in
+          let body = c_expr body in
+          let upvars = List.map ~f:c_expr upvars in
+          Closure { body; params; captures = upvars }
+      | Index { index; lhs } ->
+          let index_type = c_ty index.span index.ty in
+          let lhs_type = c_ty lhs.span lhs.ty in
+          call
+            (mk_global ([ lhs_type; index_type ] ->. typ)
+            @@ Global_ident.of_name Value Core__ops__index__Index__index)
+            [ lhs; index ]
+      | StaticRef { def_id = id; _ } -> GlobalVar (def_id Value id)
+      | PlaceTypeAscription _ ->
+          unimplemented [ e.span ] "expression PlaceTypeAscription"
+      | ValueTypeAscription _ ->
+          unimplemented [ e.span ] "expression ValueTypeAscription"
+      | ZstLiteral _ -> unimplemented [ e.span ] "expression ZstLiteral"
+      | Yield _ -> unimplemented [ e.span ] "expression Yield"
+      | Todo payload -> unimplemented [ e.span ] ("expression Todo\n" ^ payload)
+    in
+    { e = v; span; typ }
+
+  and c_lhs lhs =
+    match lhs.e with
+    | LocalVar var -> LhsLocalVar { var; typ = lhs.typ }
+    | _ -> (
+        match resugar_index_mut lhs with
+        | Some (e, index) ->
+            LhsArrayAccessor
+              { e = c_lhs e; typ = lhs.typ; index; witness = W.nontrivial_lhs }
+        | None -> (
+            match (U.unbox_underef_expr lhs).e with
+            | App
+                {
+                  f =
+                    {
+                      e = GlobalVar (`Projector _ as field);
+                      typ = TArrow ([ _ ], _);
+                      span = _;
+                    };
+                  args = [ e ];
+                } ->
+                LhsFieldAccessor
+                  {
+                    e = c_lhs e;
+                    typ = lhs.typ;
+                    field;
+                    witness = W.nontrivial_lhs;
+                  }
+            | _ -> LhsArbitraryExpr { e = lhs; witness = W.arbitrary_lhs }))
+
+  and c_expr_assign lhs rhs =
+    Assign { lhs = c_lhs lhs; e = rhs; witness = W.mutable_variable }
+
+  and c_constant_expr (ce : Thir.decorated_for__constant_expr_kind) : expr =
+    let rec constant_expr_to_expr (ce : Thir.decorated_for__constant_expr_kind)
+        : Thir.decorated_for__expr_kind =
+      {
+        attributes = ce.attributes;
+        contents = constant_expr_kind_to_expr_kind ce.contents ce.span;
+        hir_id = ce.hir_id;
+        span = ce.span;
+        ty = ce.ty;
+      }
+    and constant_expr_kind_to_expr_kind (ce : Thir.constant_expr_kind) span :
+        Thir.expr_kind =
+      match ce with
+      | Literal lit ->
+          let lit, neg = constant_lit_to_lit lit in
+          Literal { lit = { node = lit; span }; neg }
+      | Adt { fields; info } ->
+          let fields = List.map ~f:constant_field_expr fields in
+          Adt { fields; info; base = None; user_ty = None }
+      | Array { fields } ->
+          Array { fields = List.map ~f:constant_expr_to_expr fields }
+      | Tuple { fields } ->
+          Tuple { fields = List.map ~f:constant_expr_to_expr fields }
+      | GlobalName { id } -> GlobalName { id }
+      | Borrow arg ->
+          Borrow { arg = constant_expr_to_expr arg; borrow_kind = Thir.Shared }
+      | ConstRef { id } -> ConstRef { id }
+      | Todo _ -> unimplemented [ span ] "ConstantExpr::Todo"
+    and constant_lit_to_lit (l : Thir.constant_literal) : Thir.lit_kind * bool =
+      match l with
+      | Bool v -> (Bool v, false)
+      | Char v -> (Char v, false)
+      | Int (Int (v, ty)) -> (
+          match String.chop_prefix v ~prefix:"-" with
+          | Some v -> (Int (v, Signed ty), true)
+          | None -> (Int (v, Signed ty), false))
+      | Int (Uint (v, ty)) -> (Int (v, Unsigned ty), false)
+      | ByteStr (v, style) -> (ByteStr (v, style), false)
+    and constant_field_expr ({ field; value } : Thir.constant_field_expr) :
+        Thir.field_expr =
+      { field; value = constant_expr_to_expr value }
+    in
+    c_expr (constant_expr_to_expr ce)
+
+  and c_pat (pat : Thir.decorated_for__pat_kind) : pat =
+    let span = Span.of_thir pat.span in
+    let typ = c_ty pat.span pat.ty in
+    let v =
+      match pat.contents with
+      | Wild -> PWild
+      | AscribeUserType { ascription = { annotation; _ }; subpattern } ->
+          let typ, typ_span = c_canonical_user_type_annotation annotation in
+          let pat = c_pat subpattern in
+          PAscription { typ; typ_span; pat }
+      | Binding { mode; mutability; subpattern; ty; var; _ } ->
+          let mut = c_mutability W.mutable_variable mutability in
+          let subpat =
+            Option.map ~f:(c_pat &&& Fn.const W.as_pattern) subpattern
+          in
+          let typ = c_ty pat.span ty in
+          let mode = c_binding_mode pat.span mode in
+          let var = local_ident Expr var in
+          PBinding { mut; mode; var; typ; subpat }
+      | Variant { info; subpatterns; _ } ->
+          let name =
+            def_id (Constructor { is_struct = info.typ_is_struct }) info.variant
+          in
+          let args = List.map ~f:(c_field_pat info) subpatterns in
+          PConstruct
+            {
+              name;
+              args;
+              is_record = info.variant_is_record;
+              is_struct = info.typ_is_struct;
+            }
+      | Tuple { subpatterns } ->
+          (List.map ~f:c_pat subpatterns |> U.make_tuple_pat').p
+      | Deref { subpattern } ->
+          PDeref { subpat = c_pat subpattern; witness = W.reference }
+      | Constant { value } ->
+          let rec pat_of_expr (e : expr) =
+            { p = pat'_of_expr' e.e e.span; span = e.span; typ = e.typ }
+          and pat'_of_expr' (e : expr') span =
+            match e with
+            | Literal lit -> PConstant { lit }
+            | Array l -> PArray { args = List.map ~f:pat_of_expr l }
+            | Borrow { kind = _; e; witness } ->
+                PDeref { subpat = pat_of_expr e; witness }
+            | _ ->
+                assertion_failure (Span.to_thir span)
+                  ("expected a pattern, got " ^ [%show: expr'] e)
+          in
+          (c_constant_expr value |> pat_of_expr).p
+      | Array _ -> unimplemented [ pat.span ] "Pat:Array"
+      | Or _ ->
+          unimplemented [ pat.span ] ~issue_id:161
+            "Or patterns (see \
+             https://rust-lang.github.io/rfcs/2535-or-patterns.html)"
+      | Slice _ -> unimplemented [ pat.span ] "pat Slice"
+      | Range _ -> unimplemented [ pat.span ] "pat Range"
+    in
+    { p = v; span; typ }
+
+  and c_field_pat _info (field_pat : Thir.field_pat) : field_pat =
+    { field = def_id Field field_pat.field; pat = c_pat field_pat.pattern }
+
+  and extended_literal_of_expr (e : expr) : extended_literal =
+    let not_a_literal () =
+      assertion_failure (Span.to_thir e.span)
+        ("expected a literal, got " ^ [%show: expr] e)
+    in
+    match e.e with
+    | Literal lit -> EL_Lit lit
+    | Array lits ->
+        EL_U8Array
+          (List.map
+             ~f:(function
+               | {
+                   e =
+                     Literal
+                       (Int { kind = { size = S8; signedness = Unsigned }; _ }
+                       as lit);
+                   _;
+                 } ->
+                   lit
+               | _ -> not_a_literal ())
+             lits)
+    | _ -> not_a_literal ()
+
+  and c_canonical_user_type_annotation
+      (annotation : Thir.canonical_user_type_annotation) : ty * span =
+    (c_ty annotation.span annotation.inferred_ty, Span.of_thir annotation.span)
+
+  and c_pointer e typ span cast source =
+    match cast with
+    | ReifyFnPointer ->
+        (* we have arrow types, we do not distinguish between top-level functions and closures *)
+        (c_expr source).e
+    | Unsize ->
+        (* https://doc.rust-lang.org/std/marker/trait.Unsize.html *)
+        (U.call Rust_primitives__unsize [ c_expr source ] span typ).e
+        (* let source = c_expr source in *)
+        (* let from_typ = source.typ in *)
+        (* let to_typ = typ in *)
+        (* match (U.Box.Ty.destruct from_typ, U.Box.Ty.destruct to_typ) with *)
+        (* | Some _from_typ, Some to_typ -> ( *)
+        (*     match U.Box.Expr.destruct source with *)
+        (*     | Some source -> *)
+        (*         (U.Box.Expr.make *)
+        (*         @@ U.call "dummy" "unsize_cast" [] [ source ] span to_typ) *)
+        (*           .e *)
+        (*     | _ -> *)
+        (*         unimplemented e.span *)
+        (*           "[Pointer(Unsize)] cast from not directly boxed expression") *)
+        (* | _ -> *)
+        (*     unimplemented e.span *)
+        (*       ("[Pointer(Unsize)] cast\n • from type [" *)
+        (*       ^ [%show: ty] from_typ *)
+        (*       ^ "]\n • to type [" *)
+        (*       ^ [%show: ty] to_typ *)
+        (*       ^ "]\n\nThe expression is: " *)
+        (*       ^ [%show: expr] source)) *)
+    | _ ->
+        unimplemented [ e.span ]
+          ("Pointer, with [cast] being " ^ [%show: Thir.pointer_cast] cast)
+
+  and c_ty (span : Thir.span) (ty : Thir.ty) : ty =
+    match ty with
+    | Bool -> TBool
+    | Char -> TChar
+    | Int k -> TInt (c_int_ty k)
+    | Uint k -> TInt (c_uint_ty k)
+    | Float k -> TFloat (match k with F32 -> F32 | F64 -> F64)
+    | Arrow value ->
+        let ({ inputs; output; _ } : Thir.ty_fn_sig) = value.value in
+        TArrow (List.map ~f:(c_ty span) inputs, c_ty span output)
+    | Adt { def_id = id; generic_args } ->
+        let ident = def_id Type id in
+        let args = List.map ~f:(c_generic_value span) generic_args in
+        TApp { ident; args }
+    | Foreign _ -> unimplemented [ span ] "Foreign"
+    | Str -> TStr
+    | Array (ty, len) ->
+        TArray { typ = c_ty span ty; length = c_constant_expr len }
+    | Slice ty ->
+        let ty = c_ty span ty in
+        TSlice { ty; witness = W.slice }
+    | RawPtr _ -> TRawPointer { witness = W.raw_pointer }
+    | Ref (_region, ty, mut) ->
+        let typ = c_ty span ty in
+        let mut = c_mutability W.mutable_reference mut in
+        TRef { witness = W.reference; region = "todo"; typ; mut }
+    | Never -> U.never_typ
+    | Tuple types ->
+        let types = List.map ~f:(fun ty -> GType (c_ty span ty)) types in
+        TApp { ident = `TupleType (List.length types); args = types }
+    | Alias (_kind, { trait_def_id = Some (_did, impl_expr); def_id; _ }) ->
+        let impl = c_impl_expr span impl_expr in
+        let item = Concrete_ident.of_def_id (AssociatedItem Type) def_id in
+        TAssociatedType { impl; item }
+    | Alias (_kind, { def_id; trait_def_id = None; _ }) ->
+        TOpaque (Concrete_ident.of_def_id Type def_id)
+    | Param { index; name } ->
+        (* TODO: [id] might not unique *)
+        TParam { name; id = LocalIdent.mk_id Typ (MyInt64.to_int_exn index) }
+    | Error -> unimplemented [ span ] "type Error"
+    | Dynamic _ -> unimplemented [ span ] "type Dynamic"
+    | Generator _ -> unimplemented [ span ] "type Generator"
+    | Placeholder _ -> unimplemented [ span ] "type Placeholder"
+    | Bound _ -> unimplemented [ span ] "type Bound"
+    | Infer _ -> unimplemented [ span ] "type Infer"
+    | Todo _ -> unimplemented [ span ] "type Todo"
+  (* fun _ -> Ok Bool *)
+
+  and c_impl_expr (span : Thir.span) (ie : Thir.impl_expr) : impl_expr =
+    let impl = c_impl_expr_atom span ie.impl in
+    match ie.args with
+    | [] -> impl
+    | args ->
+        let args = List.map ~f:(c_impl_expr span) args in
+        ImplApp { impl; args }
+
+  and c_impl_expr_atom (span : Thir.span) (ie : Thir.impl_expr_atom) : impl_expr
+      =
+    let c_trait_ref (tr : Thir.trait_ref) : trait_ref =
+      let trait = Concrete_ident.of_def_id Trait tr.def_id in
+      let args = List.map ~f:(c_generic_value span) tr.generic_args in
+      { trait; args }
+    in
+    match ie with
+    | Concrete { id; generics } ->
+        let trait = Concrete_ident.of_def_id Trait id in
+        let args = List.map ~f:(c_generic_value span) generics in
+        Concrete { trait; args }
+    | LocalBound { clause_id; path } ->
+        let init = LocalBound { id = clause_id } in
+        let f (impl : impl_expr) (chunk : Thir.impl_expr_path_chunk) =
+          match chunk with
+          | AssocItem (item, { trait_ref; _ }) ->
+              let trait = c_trait_ref trait_ref in
+              let kind : Concrete_ident.Kind.t =
+                match item.kind with Const | Fn -> Value | Type -> Type
+              in
+              let item = Concrete_ident.of_def_id kind item.def_id in
+              Projection { impl; trait; item }
+          | Parent { trait_ref; _ } ->
+              let trait = c_trait_ref trait_ref in
+              Parent { impl; trait }
+        in
+        List.fold ~init ~f path
+    | Dyn { trait } -> Dyn (c_trait_ref trait)
+    | Builtin { trait } -> Builtin (c_trait_ref trait)
+    | Todo str -> failwith @@ "impl_expr_atom: Todo " ^ str
+
+  and c_generic_value (span : Thir.span) (ty : Thir.generic_arg) : generic_value
+      =
+    match ty with
+    | Type ty -> GType (c_ty span ty)
+    | Const e -> GConst (c_constant_expr e)
+    | _ -> GLifetime { lt = "todo generics"; witness = W.lifetime }
+
+  and c_arm (arm : Thir.arm) : arm =
+    let arm_pat = c_pat arm.pattern in
+    let body = c_expr arm.body in
+    let span = Span.of_thir arm.span in
+    { arm = { arm_pat; body }; span }
+
+  and c_param span (param : Thir.param) : param =
+    {
+      typ_span = Option.map ~f:Span.of_thir param.ty_span;
+      typ = c_ty (Option.value ~default:span param.ty_span) param.ty;
+      pat = c_pat (Option.value_exn param.pat);
+      attrs = c_attrs param.attributes;
+    }
+
+  let c_generic_param (param : Thir.generic_param) : generic_param =
+    let ident =
+      let kind =
+        match (param.kind : Thir.generic_param_kind) with
+        | Lifetime _ -> LocalIdent.LILifetime
+        | Type _ -> LocalIdent.Typ
+        | Const _ -> LocalIdent.Cnst
+      in
+      match param.name with
+      | Fresh ->
+          (* fail with ("[Fresh] ident? " ^ Thir.show_generic_param param) *)
+          (* TODO might be wrong to just have a wildcard here *)
+          ({ name = "_"; id = LocalIdent.mk_id kind 123 } : local_ident)
+      | Error -> assertion_failure [ param.span ] "[Error] ident"
+      | Plain n -> local_ident kind n
+    in
+    let kind =
+      match (param.kind : Thir.generic_param_kind) with
+      | Lifetime _ -> GPLifetime { witness = W.lifetime }
+      | Type { default; _ } ->
+          let default = Option.map ~f:(c_ty param.span) default in
+          GPType { default }
+      | Const { default = Some _; _ } ->
+          unimplemented [ param.span ] "c_generic_param:Const with a default"
+      | Const { default = None; ty } -> GPConst { typ = c_ty param.span ty }
+    in
+    let span = Span.of_thir param.span in
+    let attrs = c_attrs param.attributes in
+    { ident; span; attrs; kind }
+
+  let c_predicate_kind' span (p : Thir.predicate_kind) :
+      (trait_ref * string) option =
+    match p with
+    | Clause
+        { kind = Trait { is_positive = true; is_const = _; trait_ref }; id } ->
+        let args = List.map ~f:(c_generic_value span) trait_ref.generic_args in
+        let trait = Concrete_ident.of_def_id Trait trait_ref.def_id in
+        Some ({ trait; args }, id)
+    | _ -> None
+
+  let c_predicate_kind span (p : Thir.predicate_kind) : trait_ref option =
+    c_predicate_kind' span p |> Option.map ~f:fst
+
+  let list_dedup (equal : 'a -> 'a -> bool) : 'a list -> 'a list =
+    let rec aux (seen : 'a list) (todo : 'a list) : 'a list =
+      match todo with
+      | hd :: tl ->
+          if List.mem ~equal seen hd then aux seen tl
+          else hd :: aux (hd :: seen) tl
+      | _ -> todo
+    in
+    aux []
+
+  let c_generics (generics : Thir.generics) : generics =
+    let bounds =
+      List.filter_map ~f:(c_predicate_kind' generics.span) generics.bounds
+      |> List.map ~f:(fun (trait, id) : generic_constraint ->
+             GCType { bound = trait; id })
+    in
+    {
+      params = List.map ~f:c_generic_param generics.params;
+      constraints = bounds |> list_dedup equal_generic_constraint;
+    }
+
+  let c_trait_item' (super : Thir.trait_item) (item : Thir.trait_item_kind) :
+      trait_item' =
+    let span = super.span in
+    match item with
+    | Const (_, Some _) ->
+        unimplemented [ span ]
+          "TODO: traits: no support for defaults in traits for now"
+    | Const (ty, None) -> TIFn (c_ty span ty)
+    | ProvidedFn (sg, _) | RequiredFn (sg, _) ->
+        let (Thir.{ inputs; output; _ } : Thir.fn_decl) = sg.decl in
+        let output =
+          match output with
+          | DefaultReturn _span -> unit_typ
+          | Return ty -> c_ty span ty
+        in
+        TIFn (TArrow (List.map ~f:(c_ty span) inputs, output))
+    | Type (bounds, None) ->
+        let bounds = List.filter_map ~f:(c_predicate_kind span) bounds in
+        TIType bounds
+    | Type (_, Some _) ->
+        unimplemented [ span ]
+          "TODO: traits: no support for defaults in type for now"
 end
 
-let c_item inclusion_clauses (item : Thir.item) : (item list, error) Result.t =
-  let (module M) =
-    (module Make (struct
-      let inclusion_clauses = inclusion_clauses
-    end) : MakeT)
-  in
-  M.c_item item
+let make ~krate : (module EXPR) =
+  let is_core_item = String.(krate = "core" || krate = "core_hax_model") in
+  let module M : EXPR = Make (struct
+    let is_core_item = is_core_item
+  end) in
+  (module M)
+
+let c_trait_item (item : Thir.trait_item) : trait_item =
+  let open (val make ~krate:item.owner_id.krate : EXPR) in
+  let { params; constraints } = c_generics item.generics in
+  (* TODO: see TODO in impl items *)
+  let ti_ident = Concrete_ident.of_def_id Field item.owner_id in
+  {
+    ti_span = Span.of_thir item.span;
+    ti_generics = { params; constraints };
+    ti_v = c_trait_item' item item.kind;
+    ti_ident;
+    ti_attrs = c_item_attrs item.attributes;
+  }
+
+let is_automatically_derived (attrs : Thir.attribute list) =
+  List.exists (* We need something better here, see issue #108 *)
+    ~f:(function
+      | { kind = Normal { item = { path; _ }; _ }; _ } ->
+          String.equal path "automatically_derived"
+      | _ -> false)
+    attrs
+
+let is_hax_skip (attrs : Thir.attribute list) =
+  List.exists
+    ~f:(function
+      | { kind = Normal { item = { path; _ }; _ }; _ } ->
+          String.equal path "_hax::skip"
+      | _ -> false)
+    attrs
+
+let should_skip (attrs : Thir.item_attributes) =
+  let attrs = attrs.attributes @ attrs.parent_attributes in
+  is_hax_skip attrs || is_automatically_derived attrs
+
+let rec c_item (item : Thir.item) : item list =
+  try c_item_unwrapped item with Diagnostics.SpanFreeError.Exn _kind -> []
+
+and c_item_unwrapped (item : Thir.item) : item list =
+  let open (val make ~krate:item.owner_id.krate : EXPR) in
+  let ident = Concrete_ident.of_def_id Value item.owner_id in
+  if should_skip item.attributes then []
+  else
+    let span = Span.of_thir item.span in
+    let mk_one v =
+      let attrs = c_item_attrs item.attributes in
+      { span; v; ident; attrs }
+    in
+    let mk v = [ mk_one v ] in
+    (* TODO: things might be unnamed (e.g. constants) *)
+    match (item.kind : Thir.item_kind) with
+    | Const (_, body) ->
+        mk
+        @@ Fn
+             {
+               name =
+                 Concrete_ident.of_def_id Value (Option.value_exn item.def_id);
+               generics = { params = []; constraints = [] };
+               body = c_expr body;
+               params = [];
+             }
+    | TyAlias (ty, generics) ->
+        mk
+        @@ TyAlias
+             {
+               name =
+                 Concrete_ident.of_def_id Type (Option.value_exn item.def_id);
+               generics = c_generics generics;
+               ty = c_ty item.span ty;
+             }
+    | Fn (generics, { body; params; _ }) ->
+        mk
+        @@ Fn
+             {
+               name =
+                 Concrete_ident.of_def_id Value (Option.value_exn item.def_id);
+               generics = c_generics generics;
+               body = c_expr body;
+               params = List.map ~f:(c_param item.span) params;
+             }
+    | Enum (variants, generics) ->
+        let def_id = Option.value_exn item.def_id in
+        let generics = c_generics generics in
+        let is_struct = false in
+        let variants =
+          let kind = Concrete_ident.Kind.Constructor { is_struct } in
+          List.map
+            ~f:(fun { data; def_id = variant_id; attributes; _ } ->
+              let is_record = [%matches? Types.Struct (_ :: _, _)] data in
+              let name = Concrete_ident.of_def_id kind variant_id in
+              let arguments =
+                match data with
+                | Tuple (fields, _, _) | Struct (fields, _) ->
+                    List.map
+                      ~f:(fun { def_id = id; ty; span; attributes; _ } ->
+                        ( Concrete_ident.of_def_id Field id,
+                          c_ty span ty,
+                          c_attrs attributes ))
+                      fields
+                | Unit _ -> []
+              in
+              let attrs = c_attrs attributes in
+              { name; arguments; is_record; attrs })
+            variants
+        in
+        let name = Concrete_ident.of_def_id Type def_id in
+        mk @@ Type { name; generics; variants; is_struct }
+    | Struct (v, generics) ->
+        let generics = c_generics generics in
+        let def_id = Option.value_exn item.def_id in
+        let is_struct = true in
+        (* repeating the attributes of the item in the variant: TODO is that ok? *)
+        let attrs = c_item_attrs item.attributes in
+        let v =
+          let kind = Concrete_ident.Kind.Constructor { is_struct } in
+          let name = Concrete_ident.of_def_id kind def_id in
+          let mk fields is_record =
+            let arguments =
+              List.map
+                ~f:(fun Thir.{ def_id = id; ty; span; attributes; _ } ->
+                  ( Concrete_ident.of_def_id Field id,
+                    c_ty span ty,
+                    c_attrs attributes ))
+                fields
+            in
+            { name; arguments; is_record; attrs }
+          in
+          match v with
+          | Tuple (fields, _, _) -> mk fields false
+          | Struct ((_ :: _ as fields), _) -> mk fields true
+          | _ -> { name; arguments = []; is_record = false; attrs }
+        in
+        let variants = [ v ] in
+        let name = Concrete_ident.of_def_id Type def_id in
+        mk @@ Type { name; generics; variants; is_struct }
+    | MacroInvokation { macro_ident; argument; span } ->
+        mk
+        @@ IMacroInvokation
+             {
+               macro = Concrete_ident.of_def_id Macro macro_ident;
+               argument;
+               span = Span.of_thir span;
+               witness = W.macro;
+             }
+    | Trait (No, Normal, generics, _bounds, items) ->
+        let items =
+          List.filter
+            ~f:(fun { attributes; _ } -> not (should_skip attributes))
+            items
+        in
+        let name =
+          Concrete_ident.of_def_id Trait (Option.value_exn item.def_id)
+        in
+        let { params; constraints } = c_generics generics in
+        let self =
+          let id = LocalIdent.mk_id Typ 0 (* todo *) in
+          let ident = LocalIdent.{ name = "Self"; id } in
+          let kind = GPType { default = None } in
+          { ident; span; attrs = []; kind }
+        in
+        let params = self :: params in
+        let generics = { params; constraints } in
+        let items = List.map ~f:c_trait_item items in
+        mk @@ Trait { name; generics; items }
+    | Trait (Yes, _, _, _, _) -> unimplemented [ item.span ] "Auto trait"
+    | Trait (_, Unsafe, _, _, _) -> unimplemented [ item.span ] "Unsafe trait"
+    | Impl { of_trait = None; generics; items; _ } ->
+        let items =
+          List.filter
+            ~f:(fun { attributes; _ } -> not (should_skip attributes))
+            items
+        in
+        List.map
+          ~f:(fun (item : Thir.impl_item) ->
+            let item_def_id = Concrete_ident.of_def_id Impl item.owner_id in
+            let v =
+              match (item.kind : Thir.impl_item_kind) with
+              | Fn { body; params; _ } ->
+                  Fn
+                    {
+                      name = item_def_id;
+                      generics = c_generics generics;
+                      body = c_expr body;
+                      params = List.map ~f:(c_param item.span) params;
+                    }
+              | Const (_ty, e) ->
+                  Fn
+                    {
+                      name = item_def_id;
+                      generics = c_generics generics;
+                      (* does that make sense? can we have `const<T>`? *)
+                      body = c_expr e;
+                      params = [];
+                    }
+              | Type _ty ->
+                  assertion_failure [ item.span ]
+                    "Inherent implementations are not supposed to have \
+                     associated types \
+                     (https://doc.rust-lang.org/reference/items/implementations.html#inherent-implementations)."
+            in
+            let ident = Concrete_ident.of_def_id Value item.owner_id in
+            let attrs = c_item_attrs item.attributes in
+            { span = Span.of_thir item.span; v; ident; attrs })
+          items
+    | Impl { unsafety = Unsafe; _ } -> unsafe_block [ item.span ]
+    | Impl
+        {
+          of_trait = Some of_trait;
+          generics;
+          self_ty;
+          items;
+          unsafety = Normal;
+          _;
+        } ->
+        let items =
+          List.filter
+            ~f:(fun { attributes; _ } -> not (should_skip attributes))
+            items
+        in
+        mk
+        @@ Impl
+             {
+               generics = c_generics generics;
+               self_ty = c_ty item.span self_ty;
+               of_trait =
+                 ( def_id Trait of_trait.def_id,
+                   List.map ~f:(c_generic_value item.span) of_trait.generic_args
+                 );
+               items =
+                 List.map
+                   ~f:(fun (item : Thir.impl_item) ->
+                     (* TODO: introduce a Kind.TraitImplItem or
+                        something. Otherwise we have to assume every
+                        backend will see traits and impls as
+                        records. See https://github.com/hacspec/hacspec-v2/issues/271. *)
+                     let ii_ident =
+                       Concrete_ident.of_def_id Field item.owner_id
+                     in
+                     {
+                       ii_span = Span.of_thir item.span;
+                       ii_generics = c_generics item.generics;
+                       ii_v =
+                         (match (item.kind : Thir.impl_item_kind) with
+                         | Fn { body; params; _ } ->
+                             IIFn
+                               {
+                                 body = c_expr body;
+                                 params = List.map ~f:(c_param item.span) params;
+                               }
+                         | Const (_ty, e) ->
+                             IIFn { body = c_expr e; params = [] }
+                         | Type ty -> IIType (c_ty item.span ty));
+                       ii_ident;
+                       ii_attrs = c_item_attrs item.attributes;
+                     })
+                   items;
+             }
+    | Use ({ span = _; res; segments; rename }, _) ->
+        let v =
+          Use
+            {
+              path = List.map ~f:(fun x -> fst x.ident) segments;
+              is_external =
+                List.exists ~f:(function Err -> true | _ -> false) res;
+              (* TODO: this should represent local/external? *)
+              rename;
+            }
+        in
+        (* ident is supposed to always be an actual item, thus here we need to cheat a bit *)
+        (* TODO: is this DUMMY thing really needed? there's a `Use` segment (see #272) *)
+        let def_id = item.owner_id in
+        let def_id : Types.def_id =
+          {
+            def_id with
+            path =
+              def_id.path
+              @ [
+                  Types.
+                    { data = ValueNs "DUMMY"; disambiguator = MyInt64.of_int 0 };
+                ];
+          }
+        in
+        let attrs = c_item_attrs item.attributes in
+        [ { span; v; ident = Concrete_ident.of_def_id Value def_id; attrs } ]
+    | ExternCrate _ | Static _ | Macro _ | Mod _ | ForeignMod _ | GlobalAsm _
+    | OpaqueTy _ | Union _ | TraitAlias _ ->
+        mk NotImplementedYet
+
+let c_item _inclusion_clauses (item : Thir.item) : (item list, error) Result.t =
+  c_item item
   |> List.map
        ~f:
          (U.Mappers.rename_generic_constraints#visit_item

--- a/engine/lib/import_thir.mli
+++ b/engine/lib/import_thir.mli
@@ -1,15 +1,3 @@
-type error =
-  | UnsafeBlock
-  | LetElse
-  | LetWithoutInit
-  | GotErrLiteral
-  | BadSpanUnion
-  | ShallowMutUnsupported
-  | GotTypeInLitPat
-  | IllTypedIntLiteral
-[@@deriving show]
-
-val c_item :
-  Types.inclusion_clause list ->
+val import_item :
   Types.item_for__decorated_for__expr_kind ->
-  (Ast.Rust.item list, error) Result.t
+  Concrete_ident.t * (Ast.Rust.item list * Diagnostics.t list)

--- a/engine/lib/phases/phase_and_mut_defsite.ml
+++ b/engine/lib/phases/phase_and_mut_defsite.ml
@@ -100,7 +100,7 @@ struct
          into
           `(let … = … in)* let output = expr in output` *)
       let wrap_in_identity_let (e : expr) : expr =
-        let var = LocalIdent.{ id = var_id_of_int 0; name = "output" } in
+        let var = LocalIdent.{ id = mk_id Expr 0; name = "output" } in
         let f (e : expr) : expr =
           match e.e with
           | GlobalVar (`TupleCons 0) -> e
@@ -248,9 +248,7 @@ struct
               | TIFn (TArrow (inputs, output)) ->
                   (* Here, we craft a dummy function so that we can
                      call `rewrite_function` *)
-                  let var =
-                    LocalIdent.{ id = var_id_of_int 0; name = "dummy" }
-                  in
+                  let var = LocalIdent.{ id = mk_id Expr 0; name = "dummy" } in
                   let params =
                     List.map
                       ~f:(fun typ ->

--- a/engine/lib/phases/phase_direct_and_mut.ml
+++ b/engine/lib/phases/phase_direct_and_mut.ml
@@ -167,7 +167,7 @@ struct
               | Either.First (place : Place.t) ->
                   let var =
                     LocalIdent.
-                      { id = var_id_of_int 0; name = "tmp" ^ Int.to_string i }
+                      { id = mk_id Expr 0; name = "tmp" ^ Int.to_string i }
                   in
                   Some (var, place_to_lhs place)
               | _ -> None
@@ -179,7 +179,7 @@ struct
             List.mapi ~f:(fun i -> to_ident_lhs i &&& to_ty_span) mutargs
           in
 
-          let out_var = LocalIdent.{ id = var_id_of_int 0; name = "out" } in
+          let out_var = LocalIdent.{ id = mk_id Expr 0; name = "out" } in
           let otype = dty f.span otype in
           let pat =
             let out =

--- a/engine/lib/phases/phase_direct_and_mut.ml
+++ b/engine/lib/phases/phase_direct_and_mut.ml
@@ -235,7 +235,7 @@ struct
               let body =
                 let init =
                   if UB.is_unit_typ otype then UB.unit_expr f.span
-                  else B.{ typ = pat.typ; span = f.span; e = LocalVar out_var }
+                  else B.{ typ = otype; span = f.span; e = LocalVar out_var }
                 in
                 List.fold_right ~init ~f:UB.make_seq assigns
               in

--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -130,14 +130,8 @@ struct
         B.generic_constraint option =
       match p with
       | GCLifetime _ -> None
-      | GCType { typ; implements; id } ->
-          Some
-            (B.GCType
-               {
-                 typ = dty span typ;
-                 implements = dtrait_ref span implements;
-                 id;
-               })
+      | GCType { bound; id } ->
+          Some (B.GCType { bound = dtrait_ref span bound; id })
 
     let dgenerics (span : span) (g : A.generics) : B.generics =
       {

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -153,7 +153,8 @@ module Raw = struct
           List.map ~f:(pty span) (inputs @ [ output ]) |> concat ~sep:!" -> "
         in
         !"arrow!(" & arrow & !")"
-    | TProjectedAssociatedType _ -> !"proj_asso_type!()"
+    | TAssociatedType _ -> !"proj_asso_type!()"
+    | TOpaque ident -> !(Concrete_ident_view.show ident)
 
   and pgeneric_value span (e : generic_value) : AnnotatedString.t =
     match e with
@@ -356,7 +357,7 @@ module Raw = struct
         !"<" & concat ~sep:!", " (List.map ~f:pgeneric_param pl) & !">"
     | _ -> empty
 
-  let ptrait_ref span { trait; args; bindings = _ } =
+  let ptrait_ref span { trait; args } =
     let ( ! ) = pure span in
     let args = List.map ~f:(pgeneric_value span) args |> concat ~sep:!", " in
     !(Concrete_ident_view.show trait)
@@ -366,7 +367,7 @@ module Raw = struct
     let ( ! ) = pure span in
     match p with
     | GCLifetime _ -> !"'unk: 'unk"
-    | GCType { typ; implements } ->
+    | GCType { typ; implements; _ } ->
         pty span typ & !":" & ptrait_ref span implements
 
   let pgeneric_constraints span (constraints : generic_constraint list) =

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -367,8 +367,7 @@ module Raw = struct
     let ( ! ) = pure span in
     match p with
     | GCLifetime _ -> !"'unk: 'unk"
-    | GCType { typ; implements; _ } ->
-        pty span typ & !":" & ptrait_ref span implements
+    | GCType { bound; _ } -> !"_:" & ptrait_ref span bound
 
   let pgeneric_constraints span (constraints : generic_constraint list) =
     if List.is_empty constraints then empty

--- a/engine/lib/side_effect_utils.ml
+++ b/engine/lib/side_effect_utils.ml
@@ -156,7 +156,7 @@ struct
         self.fresh_id <- self.fresh_id + 1;
         {
           name = "hoist" ^ Int.to_string self.fresh_id;
-          id = LocalIdent.var_id_of_int (-1) (* todo *);
+          id = LocalIdent.mk_id Expr (-1) (* todo *);
         }
 
       let empty = { fresh_id = 0 }

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -54,8 +54,15 @@ struct
     | LocalBound { id } -> LocalBound { id }
     | Parent { impl; trait } ->
         Parent { impl = dimpl_expr span impl; trait = dtrait_ref span trait }
-    | Projection { impl; item } ->
-        Projection { impl = dimpl_expr span impl; item }
+    | Projection { impl; item; trait } ->
+        Projection
+          { impl = dimpl_expr span impl; item; trait = dtrait_ref span trait }
+    | ImplApp { impl; args } ->
+        ImplApp
+          {
+            impl = dimpl_expr span impl;
+            args = List.map ~f:(dimpl_expr span) args;
+          }
     | Dyn tr -> Dyn (dtrait_ref span tr)
     | Builtin tr -> Builtin (dtrait_ref span tr)
 
@@ -300,9 +307,7 @@ struct
         (generic_constraint : A.generic_constraint) : B.generic_constraint =
       match generic_constraint with
       | GCLifetime (lf, witness) -> B.GCLifetime (lf, S.lifetime witness)
-      | GCType { typ; implements; id } ->
-          B.GCType
-            { typ = dty span typ; implements = dtrait_ref span implements; id }
+      | GCType { bound; id } -> B.GCType { bound = dtrait_ref span bound; id }
 
     let dgenerics (span : span) (g : A.generics) : B.generics =
       {

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -406,6 +406,7 @@ struct
                 (trait_id, List.map ~f:(dgeneric_value span) trait_generics);
               items = List.map ~f:dimpl_item items;
             }
+      | Alias { name; item } -> B.Alias { name; item }
       | Use { path; is_external; rename } -> B.Use { path; is_external; rename }
       | HaxError e -> B.HaxError e
       | NotImplementedYet -> B.NotImplementedYet

--- a/frontend/exporter/Cargo.toml
+++ b/frontend/exporter/Cargo.toml
@@ -15,3 +15,4 @@ itertools.workspace = true
 hax-frontend-exporter-options.workspace = true
 tracing.workspace = true
 paste = "1.0.11"
+extension-traits = "1.0.1"

--- a/frontend/exporter/Cargo.toml
+++ b/frontend/exporter/Cargo.toml
@@ -16,3 +16,4 @@ hax-frontend-exporter-options.workspace = true
 tracing.workspace = true
 paste = "1.0.11"
 extension-traits = "1.0.1"
+lazy_static = "1.4.0"

--- a/frontend/exporter/README.md
+++ b/frontend/exporter/README.md
@@ -1,0 +1,3 @@
+# Special core extraction mode
+For now, the frontend is sensible to the `HAX_CORE_EXTRACTION_MODE`
+variable environment that enables a special mode.

--- a/frontend/exporter/src/body.rs
+++ b/frontend/exporter/src/body.rs
@@ -60,12 +60,23 @@ mod implementations {
     impl IsBody for ThirBody {
         fn body<'tcx, S: BaseState<'tcx>>(did: RLocalDefId, owner_id: ROwnerId, s: &S) -> Self {
             let (thir, expr) = get_thir(did, s);
-            expr.sinto(&State {
-                thir,
-                owner_id,
-                base: s.base(),
-                mir: (),
-            })
+            if *CORE_EXTRACTION_MODE {
+                let expr = &thir.exprs[expr.clone()];
+                Decorated {
+                    contents: Box::new(ExprKind::Tuple { fields: vec![] }),
+                    hir_id: None,
+                    attributes: vec![],
+                    ty: expr.ty.sinto(s),
+                    span: expr.span.sinto(s),
+                }
+            } else {
+                expr.sinto(&State {
+                    thir,
+                    owner_id,
+                    base: s.base(),
+                    mir: (),
+                })
+            }
         }
     }
 

--- a/frontend/exporter/src/body.rs
+++ b/frontend/exporter/src/body.rs
@@ -1,6 +1,9 @@
 use crate::prelude::*;
 
-pub use rustc_hir::{def_id::LocalDefId as RLocalDefId, hir_id::OwnerId as ROwnerId};
+pub use rustc_hir::{
+    def_id::{DefId as RDefId, LocalDefId as RLocalDefId},
+    hir_id::OwnerId as ROwnerId,
+};
 
 pub fn get_thir<'tcx, S: UnderOwnerState<'tcx>>(
     did: RLocalDefId,
@@ -15,7 +18,7 @@ pub fn get_thir<'tcx, S: UnderOwnerState<'tcx>>(
 }
 
 pub trait IsBody: Sized + Clone {
-    fn body<'tcx, S: UnderOwnerState<'tcx>>(did: RLocalDefId, owner: ROwnerId, s: &S) -> Self;
+    fn body<'tcx, S: UnderOwnerState<'tcx>>(did: RLocalDefId, s: &S) -> Self;
 }
 
 pub fn make_fn_def<'tcx, Body: IsBody, S: UnderOwnerState<'tcx>>(
@@ -24,20 +27,14 @@ pub fn make_fn_def<'tcx, Body: IsBody, S: UnderOwnerState<'tcx>>(
     s: &S,
 ) -> FnDef<Body> {
     let hir_id = body_id.hir_id;
-    let did = hir_id.clone().owner.def_id;
-    let owner_id = hir_id.clone().owner;
+    let ldid = hir_id.clone().owner.def_id;
 
-    let (thir, expr_entrypoint) = get_thir(did, s);
-    let s = &State {
-        thir: thir.clone(),
-        owner_id,
-        base: s.base(),
-        mir: (),
-    };
+    let (thir, expr_entrypoint) = get_thir(ldid, s);
+    let s = &with_owner_id(s.base(), thir.clone(), (), ldid.to_def_id());
     FnDef {
         params: thir.params.raw.sinto(s),
         ret: thir.exprs[expr_entrypoint].ty.sinto(s),
-        body: Body::body(did, owner_id, s),
+        body: Body::body(ldid, s),
         sig_span: fn_sig.span.sinto(s),
         header: fn_sig.header.sinto(s),
     }
@@ -47,26 +44,18 @@ pub fn body_from_id<'tcx, Body: IsBody, S: UnderOwnerState<'tcx>>(
     id: rustc_hir::BodyId,
     s: &S,
 ) -> Body {
-    Body::body(s.base().tcx.hir().body_owner_def_id(id), s.owner_id(), s)
+    Body::body(s.base().tcx.hir().body_owner_def_id(id), s)
 }
 
 mod implementations {
     use super::*;
     impl IsBody for () {
-        fn body<'tcx, S: UnderOwnerState<'tcx>>(
-            _did: RLocalDefId,
-            _owner: ROwnerId,
-            _s: &S,
-        ) -> Self {
+        fn body<'tcx, S: UnderOwnerState<'tcx>>(_did: RLocalDefId, _s: &S) -> Self {
             ()
         }
     }
     impl IsBody for ThirBody {
-        fn body<'tcx, S: UnderOwnerState<'tcx>>(
-            did: RLocalDefId,
-            owner_id: ROwnerId,
-            s: &S,
-        ) -> Self {
+        fn body<'tcx, S: UnderOwnerState<'tcx>>(did: RLocalDefId, s: &S) -> Self {
             let (thir, expr) = get_thir(did, s);
             if *CORE_EXTRACTION_MODE {
                 let expr = &thir.exprs[expr.clone()];
@@ -78,40 +67,22 @@ mod implementations {
                     span: expr.span.sinto(s),
                 }
             } else {
-                expr.sinto(&State {
-                    thir,
-                    owner_id,
-                    base: s.base(),
-                    mir: (),
-                })
+                expr.sinto(&with_owner_id(s.base(), thir, (), did.to_def_id()))
             }
         }
     }
 
     impl<A: IsBody, B: IsBody> IsBody for (A, B) {
-        fn body<'tcx, S: UnderOwnerState<'tcx>>(
-            did: RLocalDefId,
-            owner_id: ROwnerId,
-            s: &S,
-        ) -> Self {
-            (A::body(did, owner_id, s), B::body(did, owner_id, s))
+        fn body<'tcx, S: UnderOwnerState<'tcx>>(did: RLocalDefId, s: &S) -> Self {
+            (A::body(did, s), B::body(did, s))
         }
     }
 
     impl<MirKind: IsMirKind + Clone> IsBody for MirBody<MirKind> {
-        fn body<'tcx, S: UnderOwnerState<'tcx>>(
-            did: RLocalDefId,
-            owner_id: ROwnerId,
-            s: &S,
-        ) -> Self {
+        fn body<'tcx, S: UnderOwnerState<'tcx>>(did: RLocalDefId, s: &S) -> Self {
             let (thir, _) = get_thir(did, s);
             let mir = Rc::new(s.base().tcx.mir_built(did).borrow().clone());
-            mir.sinto(&State {
-                thir,
-                owner_id,
-                base: s.base(),
-                mir: mir.clone(),
-            })
+            mir.sinto(&with_owner_id(s.base(), thir, mir.clone(), did.to_def_id()))
         }
     }
 }

--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -252,6 +252,7 @@ pub trait ConstantExt<'tcx>: Sized + std::fmt::Debug {
         let tcx = s.base().tcx;
         if is_anon_const(ucv.def, tcx) {
             TranslateUnevalRes::EvaluatedConstant(self.eval_constant(s).unwrap_or_else(|| {
+                // TODO: This is triggered when compiling using `generic_const_exprs`
                 supposely_unreachable_fatal!(s, "TranslateUneval"; {self, ucv});
             }))
         } else {

--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -117,7 +117,7 @@ impl From<ConstantExpr> for Expr {
     }
 }
 
-pub(crate) fn scalar_int_to_constant_literal<'tcx, S: BaseState<'tcx>>(
+pub(crate) fn scalar_int_to_constant_literal<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     x: rustc_middle::ty::ScalarInt,
     ty: rustc_middle::ty::Ty,
@@ -149,7 +149,7 @@ pub(crate) fn scalar_int_to_constant_literal<'tcx, S: BaseState<'tcx>>(
     }
 }
 
-pub(crate) fn scalar_to_constant_expr<'tcx, S: BaseState<'tcx>>(
+pub(crate) fn scalar_to_constant_expr<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     ty: rustc_middle::ty::Ty<'tcx>,
     scalar: &rustc_middle::mir::interpret::Scalar,
@@ -239,14 +239,14 @@ pub enum TranslateUnevalRes<T> {
 }
 
 pub trait ConstantExt<'tcx>: Sized + std::fmt::Debug {
-    fn eval_constant<S: BaseState<'tcx>>(&self, s: &S) -> Option<Self>;
+    fn eval_constant<S: UnderOwnerState<'tcx>>(&self, s: &S) -> Option<Self>;
 
     /// Performs a one-step translation of a constant.
     ///  - When a constant refers to a named top-level constant, we want to use that, thus we translate the constant to a `ConstantExprKind::GlobalName`. This is captured by the variant `TranslateUnevalRes::GlobalName`.
     ///  - When a constant refers to a anonymous top-level constant, we evaluate it. If the evaluation fails, we report an error: we expect every AnonConst to be reducible. Otherwise, we return the variant `TranslateUnevalRes::EvaluatedConstant`.
     fn translate_uneval(
         &self,
-        s: &impl BaseState<'tcx>,
+        s: &impl UnderOwnerState<'tcx>,
         ucv: rustc_middle::ty::UnevaluatedConst,
     ) -> TranslateUnevalRes<Self> {
         let tcx = s.base().tcx;
@@ -261,18 +261,18 @@ pub trait ConstantExt<'tcx>: Sized + std::fmt::Debug {
     }
 }
 impl<'tcx> ConstantExt<'tcx> for rustc_middle::ty::Const<'tcx> {
-    fn eval_constant<S: BaseState<'tcx>>(&self, s: &S) -> Option<Self> {
+    fn eval_constant<S: UnderOwnerState<'tcx>>(&self, s: &S) -> Option<Self> {
         let evaluated = self.eval(s.base().tcx, get_param_env(s));
         (&evaluated != self).then_some(evaluated)
     }
 }
 impl<'tcx> ConstantExt<'tcx> for rustc_middle::mir::ConstantKind<'tcx> {
-    fn eval_constant<S: BaseState<'tcx>>(&self, s: &S) -> Option<Self> {
+    fn eval_constant<S: UnderOwnerState<'tcx>>(&self, s: &S) -> Option<Self> {
         let evaluated = self.eval(s.base().tcx, get_param_env(s));
         (&evaluated != self).then_some(evaluated)
     }
 }
-impl<'tcx, S: BaseState<'tcx>> SInto<S, ConstantExpr> for rustc_middle::ty::Const<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, ConstantExpr> for rustc_middle::ty::Const<'tcx> {
     fn sinto(&self, s: &S) -> ConstantExpr {
         use rustc_middle::{query::Key, ty};
         let span = self.default_span(s.base().tcx);
@@ -300,7 +300,7 @@ impl<'tcx, S: BaseState<'tcx>> SInto<S, ConstantExpr> for rustc_middle::ty::Cons
 }
 
 // #[tracing::instrument(skip(s))]
-pub(crate) fn valtree_to_constant_expr<'tcx, S: BaseState<'tcx>>(
+pub(crate) fn valtree_to_constant_expr<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     valtree: rustc_middle::ty::ValTree<'tcx>,
     ty: rustc_middle::ty::Ty<'tcx>,
@@ -364,7 +364,7 @@ pub(crate) fn valtree_to_constant_expr<'tcx, S: BaseState<'tcx>>(
     kind.decorate(ty.sinto(s), span.sinto(s))
 }
 
-pub(crate) fn const_value_reference_to_constant_expr<'tcx, S: BaseState<'tcx>>(
+pub(crate) fn const_value_reference_to_constant_expr<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     ty: rustc_middle::ty::Ty<'tcx>,
     val: rustc_middle::mir::interpret::ConstValue<'tcx>,
@@ -418,7 +418,7 @@ pub(crate) fn const_value_reference_to_constant_expr<'tcx, S: BaseState<'tcx>>(
     (ConstantExprKind::Tuple { fields }).decorate(hax_ty, span.sinto(s))
 }
 
-pub fn const_value_to_constant_expr<'tcx, S: BaseState<'tcx>>(
+pub fn const_value_to_constant_expr<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     ty: rustc_middle::ty::Ty<'tcx>,
     val: rustc_middle::mir::interpret::ConstValue<'tcx>,

--- a/frontend/exporter/src/lib.rs
+++ b/frontend/exporter/src/lib.rs
@@ -41,6 +41,7 @@ pub use hax_frontend_exporter_options as options;
 pub use prelude::*;
 
 mod sinto;
+mod traits;
 mod utils;
 
 pub use adt_into::AdtInto;

--- a/frontend/exporter/src/prelude.rs
+++ b/frontend/exporter/src/prelude.rs
@@ -11,4 +11,5 @@ pub use crate::constant_utils::*;
 pub use crate::index_vec::*;
 pub use crate::rustc_utils::*;
 pub use crate::state::*;
+pub use crate::traits::*;
 pub use crate::types::*;

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -35,7 +35,7 @@ impl<'tcx> ty::TyCtxt<'tcx> {
         let mut next_did = Some(did);
         let mut predicates = vec![];
         while let Some(did) = next_did {
-            let gen_preds = self.predicates_defined_on(did);
+            let gen_preds = self.predicates_of(did);
             next_did = gen_preds.parent;
             predicates.extend(gen_preds.predicates.into_iter())
         }

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -64,7 +64,7 @@ pub(crate) fn get_variant_information<'s, S: BaseState<'s>>(
     variant_index: rustc_abi::VariantIdx,
     s: &S,
 ) -> VariantInformations {
-    s_assert!(s, !adt_def.is_union());
+    s_assert!(s, !adt_def.is_union() || *CORE_EXTRACTION_MODE);
     fn is_record<'s, I: std::iter::Iterator<Item = &'s ty::FieldDef> + Clone>(it: I) -> bool {
         it.clone()
             .any(|field| !field.name.to_ident_string().parse::<u64>().is_ok())

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -245,7 +245,7 @@ pub(crate) fn attribute_from_scope<'tcx, S: ExprState<'tcx>>(
 ) -> (Option<rustc_hir::hir_id::HirId>, Vec<Attribute>) {
     let owner = s.owner_id();
     let tcx = s.base().tcx;
-    let scope_tree = tcx.region_scope_tree(owner.to_def_id());
+    let scope_tree = tcx.region_scope_tree(owner);
     let hir_id = scope.hir_id(scope_tree);
     let tcx = s.base().tcx;
     let map = tcx.hir();

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -43,7 +43,7 @@ impl<'tcx> ty::TyCtxt<'tcx> {
     }
 }
 
-pub fn poly_trait_ref<'tcx, S: BaseState<'tcx> + HasOwnerId>(
+pub fn poly_trait_ref<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     assoc: &ty::AssocItem,
     substs: ty::SubstsRef<'tcx>,
@@ -54,12 +54,12 @@ pub fn poly_trait_ref<'tcx, S: BaseState<'tcx> + HasOwnerId>(
 }
 
 #[tracing::instrument(skip(s))]
-pub(crate) fn arrow_of_sig<'tcx, S: BaseState<'tcx>>(sig: &ty::PolyFnSig<'tcx>, s: &S) -> Ty {
+pub(crate) fn arrow_of_sig<'tcx, S: UnderOwnerState<'tcx>>(sig: &ty::PolyFnSig<'tcx>, s: &S) -> Ty {
     Ty::Arrow(Box::new(sig.sinto(s)))
 }
 
 #[tracing::instrument(skip(s))]
-pub(crate) fn get_variant_information<'s, S: BaseState<'s>>(
+pub(crate) fn get_variant_information<'s, S: UnderOwnerState<'s>>(
     adt_def: &ty::AdtDef<'s>,
     variant_index: rustc_abi::VariantIdx,
     s: &S,
@@ -163,7 +163,7 @@ pub fn translate_span(span: rustc_span::Span, sess: &rustc_session::Session) -> 
 }
 
 #[tracing::instrument(skip(s))]
-pub(crate) fn get_param_env<'tcx, S: BaseState<'tcx>>(s: &S) -> ty::ParamEnv<'tcx> {
+pub(crate) fn get_param_env<'tcx, S: UnderOwnerState<'tcx>>(s: &S) -> ty::ParamEnv<'tcx> {
     match s.base().opt_def_id {
         Some(id) => s.base().tcx.param_env(id),
         None => ty::ParamEnv::empty(),
@@ -226,7 +226,7 @@ pub(crate) fn macro_invocation_of_raw_mac_invocation<'t, S: BaseState<'t>>(
 }
 
 #[tracing::instrument(skip(state))]
-pub(crate) fn macro_invocation_of_span<'t, S: BaseState<'t>>(
+pub(crate) fn macro_invocation_of_span<'t, S: UnderOwnerState<'t>>(
     span: rustc_span::Span,
     state: &S,
 ) -> Option<MacroInvokation> {
@@ -276,14 +276,15 @@ pub fn inline_macro_invocations<'t, S: BaseState<'t>, Body: IsBody>(
         .into_iter()
         .map(|(mac, items)| match mac.0 {
             Some((macro_ident, expn_data)) => {
-                let owner_id = items.into_iter().map(|x| x.owner_id).next().s_unwrap(s);
-                // owner_id.reduce()
+                let owner_id: rustc_hir::hir_id::OwnerId =
+                    items.into_iter().map(|x| x.owner_id).next().s_unwrap(s);
                 let invocation =
                     macro_invocation_of_raw_mac_invocation(&macro_ident, &expn_data, s);
                 let span = expn_data.call_site.sinto(s);
+                let owner_id: DefId = owner_id.sinto(s);
                 vec![Item {
                     def_id: None,
-                    owner_id: owner_id.sinto(s),
+                    owner_id,
                     kind: ItemKind::MacroInvokation(invocation),
                     span,
                     vis_span: rustc_span::DUMMY_SP.sinto(s),

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -1,23 +1,71 @@
 use crate::prelude::*;
+use rustc_middle::ty;
+
+#[extension_traits::extension(pub trait SubstBinder)]
+impl<'tcx, T: ty::TypeFoldable<ty::TyCtxt<'tcx>>> ty::Binder<'tcx, T> {
+    fn subst(self, tcx: ty::TyCtxt<'tcx>, substs: &[ty::subst::GenericArg<'tcx>]) -> T {
+        ty::EarlyBinder::bind(self.skip_binder()).subst(tcx, substs)
+    }
+}
+
+#[extension_traits::extension(pub trait PredicateToPolyTraitRef)]
+impl<'tcx> ty::Predicate<'tcx> {
+    fn as_poly_trait_ref(self) -> Option<ty::PolyTraitRef<'tcx>> {
+        self.kind()
+            .try_map_bound(|kind| {
+                if let ty::PredicateKind::Clause(ty::Clause::Trait(trait_predicate)) = kind {
+                    Ok(trait_predicate.trait_ref)
+                } else {
+                    Err(())
+                }
+            })
+            .ok()
+    }
+}
+
+#[extension_traits::extension(pub trait TyCtxtExtPredOrAbove)]
+impl<'tcx> ty::TyCtxt<'tcx> {
+    /// Just like `TyCtxt::predicates_defined_on`, but in the case of
+    /// a trait or impl item, also includes the predicates defined on
+    /// the parent.
+    fn predicates_defined_on_or_above(
+        self,
+        did: rustc_span::def_id::DefId,
+    ) -> Vec<(ty::Predicate<'tcx>, rustc_span::Span)> {
+        let mut next_did = Some(did);
+        let mut predicates = vec![];
+        while let Some(did) = next_did {
+            let gen_preds = self.predicates_defined_on(did);
+            next_did = gen_preds.parent;
+            predicates.extend(gen_preds.predicates.into_iter())
+        }
+        predicates
+    }
+}
+
+pub fn poly_trait_ref<'tcx, S: BaseState<'tcx> + HasOwnerId>(
+    s: &S,
+    assoc: &ty::AssocItem,
+    substs: ty::SubstsRef<'tcx>,
+) -> Option<ty::PolyTraitRef<'tcx>> {
+    let tcx = s.base().tcx;
+    let r#trait = tcx.trait_of_item(assoc.def_id)?;
+    Some(ty::Binder::dummy(ty::TraitRef::new(tcx, r#trait, substs)))
+}
 
 #[tracing::instrument(skip(s))]
-pub(crate) fn arrow_of_sig<'tcx, S: BaseState<'tcx>>(
-    sig: &rustc_middle::ty::PolyFnSig<'tcx>,
-    s: &S,
-) -> Ty {
+pub(crate) fn arrow_of_sig<'tcx, S: BaseState<'tcx>>(sig: &ty::PolyFnSig<'tcx>, s: &S) -> Ty {
     Ty::Arrow(Box::new(sig.sinto(s)))
 }
 
 #[tracing::instrument(skip(s))]
 pub(crate) fn get_variant_information<'s, S: BaseState<'s>>(
-    adt_def: &rustc_middle::ty::AdtDef<'s>,
+    adt_def: &ty::AdtDef<'s>,
     variant_index: rustc_abi::VariantIdx,
     s: &S,
 ) -> VariantInformations {
     s_assert!(s, !adt_def.is_union());
-    fn is_record<'s, I: std::iter::Iterator<Item = &'s rustc_middle::ty::FieldDef> + Clone>(
-        it: I,
-    ) -> bool {
+    fn is_record<'s, I: std::iter::Iterator<Item = &'s ty::FieldDef> + Clone>(it: I) -> bool {
         it.clone()
             .any(|field| !field.name.to_ident_string().parse::<u64>().is_ok())
     }
@@ -115,66 +163,11 @@ pub fn translate_span(span: rustc_span::Span, sess: &rustc_session::Session) -> 
 }
 
 #[tracing::instrument(skip(s))]
-pub(crate) fn get_param_env<'tcx, S: BaseState<'tcx>>(s: &S) -> rustc_middle::ty::ParamEnv<'tcx> {
+pub(crate) fn get_param_env<'tcx, S: BaseState<'tcx>>(s: &S) -> ty::ParamEnv<'tcx> {
     match s.base().opt_def_id {
         Some(id) => s.base().tcx.param_env(id),
-        None => rustc_middle::ty::ParamEnv::empty(),
+        None => ty::ParamEnv::empty(),
     }
-}
-
-#[tracing::instrument(skip(s))]
-#[allow(dead_code)]
-#[allow(unused)]
-pub(crate) fn _resolve_trait<'tcx, S: BaseState<'tcx>>(
-    trait_ref: rustc_middle::ty::TraitRef<'tcx>,
-    s: &S,
-) {
-    let tcx = s.base().tcx;
-    let param_env = get_param_env(s);
-    use rustc_middle::ty::Binder;
-    let binder: Binder<'tcx, _> = Binder::dummy(trait_ref);
-    use rustc_infer::infer::TyCtxtInferExt;
-    use rustc_infer::traits;
-    use rustc_middle::ty::{ParamEnv, ParamEnvAnd};
-    use rustc_trait_selection::infer::InferCtxtBuilderExt;
-    use rustc_trait_selection::traits::SelectionContext;
-    let inter_ctxt = tcx.infer_ctxt().ignoring_regions().build();
-    let mut selection_ctxt = SelectionContext::new(&inter_ctxt);
-    use std::collections::VecDeque;
-    let mut queue = VecDeque::new();
-    let obligation = traits::Obligation::new(
-        tcx,
-        traits::ObligationCause::dummy(),
-        param_env,
-        rustc_middle::ty::Binder::dummy(trait_ref),
-    );
-    use rustc_middle::traits::ImplSource;
-    queue.push_back(obligation);
-    loop {
-        match queue.pop_front() {
-            Some(obligation) => {
-                let impl_source = selection_ctxt.select(&obligation).unwrap().unwrap();
-                println!("impl_source={:#?}", impl_source);
-                let nested = impl_source.clone().nested_obligations();
-                for subobligation in nested {
-                    let bound_predicate = subobligation.predicate.kind();
-                    match bound_predicate.skip_binder() {
-                        rustc_middle::ty::PredicateKind::Clause(
-                            rustc_middle::ty::Clause::Trait(trait_pred),
-                        ) => {
-                            let trait_pred = bound_predicate.rebind(trait_pred);
-                            let subobligation = subobligation.with(tcx, trait_pred);
-                            queue.push_back(subobligation);
-                        }
-                        _ => (),
-                    }
-                }
-            }
-            None => break,
-        }
-    }
-    // let impl_source = selection_ctxt.select(&obligation).unwrap().unwrap();
-    // let nested = impl_source.clone().nested_obligations();
 }
 
 #[tracing::instrument]
@@ -268,7 +261,7 @@ pub fn inline_macro_invocations<'t, S: BaseState<'t>, Body: IsBody>(
     ids: impl Iterator<Item = rustc_hir::ItemId>,
     s: &S,
 ) -> Vec<Item<Body>> {
-    let tcx: rustc_middle::ty::TyCtxt = s.base().tcx;
+    let tcx: ty::TyCtxt = s.base().tcx;
 
     struct SpanEq(Option<(DefId, rustc_span::hygiene::ExpnData)>);
     impl core::cmp::PartialEq for SpanEq {

--- a/frontend/exporter/src/state.rs
+++ b/frontend/exporter/src/state.rs
@@ -198,6 +198,23 @@ impl<'tcx> State<Base<'tcx>, (), Rc<rustc_middle::mir::Body<'tcx>>, ()> {
     }
 }
 
+/// Updates the OnwerId in a state, making sure to override `opt_def_id` in base as well.
+// TODO: is `opt_def_id` useful at all? (see https://github.com/hacspec/hacspec-v2/issues/273)
+pub fn with_owner_id<'tcx, THIR, MIR>(
+    mut base: types::Base<'tcx>,
+    thir: THIR,
+    mir: MIR,
+    owner_id: rustc_hir::hir_id::OwnerId,
+) -> State<types::Base<'tcx>, THIR, MIR, rustc_hir::hir_id::OwnerId> {
+    base.opt_def_id = Some(owner_id.to_def_id());
+    State {
+        thir,
+        owner_id,
+        base,
+        mir,
+    }
+}
+
 pub trait BaseState<'tcx> = HasBase<'tcx> + Clone + IsState<'tcx>;
 
 /// Returns a map from every implementation (`Impl`) `DefId`s to the

--- a/frontend/exporter/src/state.rs
+++ b/frontend/exporter/src/state.rs
@@ -216,10 +216,12 @@ pub fn with_owner_id<'tcx, THIR, MIR>(
 }
 
 pub trait BaseState<'tcx> = HasBase<'tcx> + Clone + IsState<'tcx>;
+/// State of anything below a `owner_id`
+pub trait UnderOwnerState<'tcx> = BaseState<'tcx> + HasOwnerId;
 
 /// Returns a map from every implementation (`Impl`) `DefId`s to the
 /// type they implement, plus the bounds.
-pub fn impl_def_ids_to_impled_types_and_bounds<'tcx, S: BaseState<'tcx>>(
+pub fn impl_def_ids_to_impled_types_and_bounds<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
 ) -> HashMap<DefId, (Ty, Vec<Predicate>)> {
     let Base {

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -305,23 +305,6 @@ pub fn select_trait_candidate<'tcx, S: UnderOwnerState<'tcx>>(
     let obligation_cause = ObligationCause::dummy();
     let obligation = Obligation::new(tcx, obligation_cause, param_env, trait_ref);
 
-    if format!("{:#?}", obligation) == "Obligation(predicate=Binder(TraitPredicate(<_ as marker::Sized>, polarity:Positive), []), depth=0)" {
-        let tr = trait_ref.skip_binder();
-        let ty = tr.self_ty();
-        eprintln!("span={:#?}", s.base().opt_def_id.map(|did| tcx.def_span(did)));
-        eprintln!("obligation={:#?}", obligation);
-        eprintln!("ty={}", match ty.kind() {
-            rustc_middle::ty::Infer(var) => format!("Infer({:#?})", match var {
-                rustc_middle::ty::InferTy::TyVar(payload) => format!("TyVar({:?})", payload),
-                rustc_middle::ty::InferTy::IntVar(payload) => format!("IntVar({:?})", payload),
-                rustc_middle::ty::InferTy::FloatVar(payload) => format!("FloatVar({:?})", payload),
-                rustc_middle::ty::InferTy::FreshTy(payload) => format!("FreshTy({:?})", payload),
-                rustc_middle::ty::InferTy::FreshIntTy(payload) => format!("FreshIntTy({:?})", payload),
-                rustc_middle::ty::InferTy::FreshFloatTy(payload) => format!("FreshFloatTy({:?})", payload),
-            }),
-            k => format!("{:?}", k)
-        });
-    }
     let selection = {
         use std::panic;
         panic::set_hook(Box::new(|_info| {}));

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: search_clause::PathChunk<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: search_clause::PathChunk<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
 )]
@@ -45,7 +45,7 @@ pub struct ImplExpr {
 
 mod search_clause {
     use super::SubstBinder;
-    use crate::prelude::BaseState;
+    use crate::prelude::UnderOwnerState;
     use crate::rustc_utils::TyCtxtExtPredOrAbove;
     use rustc_middle::ty::*;
 
@@ -70,7 +70,7 @@ mod search_clause {
     pub type Path<'tcx> = Vec<PathChunk<'tcx>>;
 
     #[extension_traits::extension(pub trait TraitPredicateExt)]
-    impl<'tcx, S: BaseState<'tcx>> TraitPredicate<'tcx> {
+    impl<'tcx, S: UnderOwnerState<'tcx>> TraitPredicate<'tcx> {
         fn parents_trait_predicates(self, s: &S) -> Vec<TraitPredicate<'tcx>> {
             let tcx = s.base().tcx;
             let predicates = tcx
@@ -157,7 +157,7 @@ impl From<ImplExprAtom> for ImplExpr {
     }
 }
 
-fn impl_exprs<'tcx, S: BaseState<'tcx> + HasOwnerId>(
+fn impl_exprs<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     obligations: &Vec<
         rustc_trait_selection::traits::Obligation<'tcx, rustc_middle::ty::Predicate<'tcx>>,
@@ -175,7 +175,7 @@ fn impl_exprs<'tcx, S: BaseState<'tcx> + HasOwnerId>(
 }
 
 pub trait IntoImplExpr<'tcx> {
-    fn impl_expr<S: BaseState<'tcx> + HasOwnerId>(
+    fn impl_expr<S: UnderOwnerState<'tcx>>(
         &self,
         s: &S,
         param_env: rustc_middle::ty::ParamEnv<'tcx>,
@@ -183,7 +183,7 @@ pub trait IntoImplExpr<'tcx> {
 }
 
 impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
-    fn impl_expr<S: BaseState<'tcx> + HasOwnerId>(
+    fn impl_expr<S: UnderOwnerState<'tcx>>(
         &self,
         s: &S,
         param_env: rustc_middle::ty::ParamEnv<'tcx>,
@@ -277,7 +277,7 @@ pub fn clause_id_of_predicate(predicate: rustc_middle::ty::Predicate) -> u64 {
 /// TODO: returns an Option for now, `None` means we hit the indexing
 /// bug (see https://github.com/rust-lang/rust/issues/112242).
 #[tracing::instrument(level = "trace", skip(s))]
-pub fn select_trait_candidate<'tcx, S: BaseState<'tcx>>(
+pub fn select_trait_candidate<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     param_env: rustc_middle::ty::ParamEnv<'tcx>,
     trait_ref: rustc_middle::ty::PolyTraitRef<'tcx>,

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -2,13 +2,17 @@ use crate::prelude::*;
 
 #[derive(AdtInto)]
 #[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: search_clause::PathChunk<'tcx>, state: S as tcx)]
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub enum ImplExprPathChunk {
     AssocItem(AssocItem, TraitPredicate),
     Parent(TraitPredicate),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub enum ImplExprAtom {
     Concrete {
         id: GlobalIdent,
@@ -31,7 +35,9 @@ pub enum ImplExprAtom {
     Todo(String),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub struct ImplExpr {
     r#impl: ImplExprAtom,
     args: Box<Vec<ImplExpr>>,

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -1,0 +1,334 @@
+use crate::prelude::*;
+
+#[derive(AdtInto)]
+#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: search_clause::PathChunk<'tcx>, state: S as tcx)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub enum ImplExprPathChunk {
+    AssocItem(AssocItem, TraitPredicate),
+    Parent(TraitPredicate),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub enum ImplExprAtom {
+    Concrete {
+        id: GlobalIdent,
+        generics: Vec<GenericArg>,
+    },
+    LocalBound {
+        clause_id: u64,
+        path: Vec<ImplExprPathChunk>,
+    },
+    /// `dyn TRAIT` is a wrapped value with a virtual table for trait
+    /// `TRAIT`.  In other words, a value `dyn TRAIT` is a dependent
+    /// triple that gathers a type τ, a value of type τ and an
+    /// instance of type `TRAIT`.
+    Dyn {
+        r#trait: TraitRef,
+    },
+    Builtin {
+        r#trait: TraitRef,
+    },
+    Todo(String),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ImplExpr {
+    r#impl: ImplExprAtom,
+    args: Box<Vec<ImplExpr>>,
+}
+
+mod search_clause {
+    use super::SubstBinder;
+    use crate::prelude::BaseState;
+    use crate::rustc_utils::TyCtxtExtPredOrAbove;
+    use rustc_middle::ty::*;
+
+    fn predicates_to_trait_predicates<'tcx>(
+        tcx: TyCtxt<'tcx>,
+        predicates: impl Iterator<Item = Predicate<'tcx>>,
+        substs: subst::SubstsRef<'tcx>,
+    ) -> impl Iterator<Item = TraitPredicate<'tcx>> {
+        predicates
+            .map(move |pred| pred.kind().subst(tcx, substs))
+            .filter_map(|x| match x {
+                PredicateKind::Clause(Clause::Trait(c)) => Some(c),
+                _ => None,
+            })
+    }
+
+    #[derive(Clone, Debug)]
+    pub enum PathChunk<'tcx> {
+        AssocItem(AssocItem, TraitPredicate<'tcx>),
+        Parent(TraitPredicate<'tcx>),
+    }
+    pub type Path<'tcx> = Vec<PathChunk<'tcx>>;
+
+    #[extension_traits::extension(pub trait TraitPredicateExt)]
+    impl<'tcx, S: BaseState<'tcx>> TraitPredicate<'tcx> {
+        fn parents_trait_predicates(self, s: &S) -> Vec<TraitPredicate<'tcx>> {
+            let tcx = s.base().tcx;
+            let predicates = tcx
+                .predicates_defined_on_or_above(self.def_id())
+                .into_iter()
+                .map(|(predicate, _)| predicate);
+            predicates_to_trait_predicates(tcx, predicates, self.trait_ref.substs).collect()
+        }
+        fn associated_items_trait_predicates(
+            self,
+            s: &S,
+        ) -> Vec<(AssocItem, subst::EarlyBinder<Vec<TraitPredicate<'tcx>>>)> {
+            let tcx = s.base().tcx;
+            tcx.associated_items(self.def_id())
+                .in_definition_order()
+                .filter(|item| item.kind == AssocKind::Type)
+                .copied()
+                .map(|item| {
+                    let bounds = tcx.item_bounds(item.def_id).map_bound(|predicates| {
+                        predicates_to_trait_predicates(
+                            tcx,
+                            predicates.into_iter(),
+                            self.trait_ref.substs,
+                        )
+                        .collect()
+                    });
+                    (item, bounds)
+                })
+                .collect()
+        }
+
+        fn path_to(
+            self,
+            s: &S,
+            target: PolyTraitRef<'tcx>,
+            param_env: rustc_middle::ty::ParamEnv<'tcx>,
+        ) -> Option<Path<'tcx>> {
+            {
+                let self_p: Predicate = self.to_predicate(s.base().tcx);
+                let target_p: Predicate = target.to_predicate(s.base().tcx);
+                // TODO: How should we compare those? normalizing is not helping
+
+                // eprintln!("   target_p = {target_p:?}");
+                // eprintln!("VS   self_p = {self_p:?}");
+                // eprintln!("-----> {:?}", self_p == target_p);
+                if format!("{:?}", self_p) == format!("{:?}", target_p) {
+                    return Some(vec![]);
+                }
+            }
+
+            let recurse = |p: Self| p.path_to(s, target, param_env);
+            fn cons<T>(hd: T, tail: Vec<T>) -> Vec<T> {
+                vec![hd].into_iter().chain(tail.into_iter()).collect()
+            }
+            self.parents_trait_predicates(s)
+                .into_iter()
+                .filter_map(|p| recurse(p).map(|path| cons(PathChunk::Parent(p), path)))
+                .max_by_key(|path| path.len())
+                .or_else(|| {
+                    self.associated_items_trait_predicates(s)
+                        .into_iter()
+                        .filter_map(|(item, binder)| {
+                            binder.skip_binder().into_iter().find_map(|p| {
+                                recurse(p).map(|path| cons(PathChunk::AssocItem(item, p), path))
+                            })
+                        })
+                        .max_by_key(|path| path.len())
+                })
+        }
+    }
+}
+
+impl ImplExprAtom {
+    fn with_args(self, args: Vec<ImplExpr>) -> ImplExpr {
+        ImplExpr {
+            r#impl: self,
+            args: Box::new(args),
+        }
+    }
+}
+impl From<ImplExprAtom> for ImplExpr {
+    fn from(implem: ImplExprAtom) -> ImplExpr {
+        implem.with_args(vec![])
+    }
+}
+
+fn impl_exprs<'tcx, S: BaseState<'tcx> + HasOwnerId>(
+    s: &S,
+    obligations: &Vec<
+        rustc_trait_selection::traits::Obligation<'tcx, rustc_middle::ty::Predicate<'tcx>>,
+    >,
+) -> Vec<ImplExpr> {
+    obligations
+        .into_iter()
+        .flat_map(|obligation| {
+            obligation
+                .predicate
+                .as_poly_trait_ref()
+                .map(|trait_ref| trait_ref.impl_expr(s, obligation.param_env))
+        })
+        .collect()
+}
+
+pub trait IntoImplExpr<'tcx> {
+    fn impl_expr<S: BaseState<'tcx> + HasOwnerId>(
+        &self,
+        s: &S,
+        param_env: rustc_middle::ty::ParamEnv<'tcx>,
+    ) -> ImplExpr;
+}
+
+impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
+    fn impl_expr<S: BaseState<'tcx> + HasOwnerId>(
+        &self,
+        s: &S,
+        param_env: rustc_middle::ty::ParamEnv<'tcx>,
+    ) -> ImplExpr {
+        use rustc_trait_selection::traits::*;
+        let Some(impl_source) = select_trait_candidate(s, param_env, *self) else {
+            return ImplExprAtom::Todo(format!("impl_expr failed on {:#?}", self)).into();
+        };
+        match impl_source {
+            ImplSource::UserDefined(ImplSourceUserDefinedData {
+                impl_def_id,
+                substs,
+                nested,
+            }) => ImplExprAtom::Concrete {
+                id: impl_def_id.sinto(s),
+                generics: substs.sinto(s),
+            }
+            .with_args(impl_exprs(s, &nested)),
+            ImplSource::Param(nested, _constness) => {
+                use search_clause::TraitPredicateExt;
+                let tcx = s.base().tcx;
+                let predicates = &tcx.predicates_defined_on_or_above(s.owner_id().to_def_id());
+                let Some((predicate, path)) = predicates.into_iter().find_map(|(predicate, _)| {
+                    predicate
+                        .to_opt_poly_trait_pred()
+                        .map(|poly_trait_predicate| poly_trait_predicate)
+                        .and_then(|poly_trait_predicate| poly_trait_predicate.no_bound_vars())
+                        .and_then(|trait_predicate| {
+                            trait_predicate.path_to(s, self.clone(), param_env)
+                        })
+                        .map(|path| (predicate, path))
+                }) else {
+                    return ImplExprAtom::Todo(format!("implsource::param \n\n{:#?}", self))
+                        .with_args(impl_exprs(s, &nested));
+                };
+                // .s_expect(s, format!("implsource::param \n\n{:#?}", self).as_str());
+                let clause_id: u64 = clause_id_of_predicate(*predicate);
+                ImplExprAtom::LocalBound {
+                    clause_id,
+                    path: path.sinto(s),
+                }
+                .with_args(impl_exprs(s, &nested))
+            }
+            ImplSource::Object(data) => ImplExprAtom::Dyn {
+                r#trait: data.upcast_trait_ref.skip_binder().sinto(s),
+            }
+            .with_args(impl_exprs(s, &data.nested)),
+            ImplSource::Builtin(x) => ImplExprAtom::Builtin {
+                r#trait: self.skip_binder().sinto(s),
+            }
+            .with_args(impl_exprs(s, &x.nested)),
+            x => ImplExprAtom::Todo(format!("{:#?}\n\n{:#?}", x, self)).into(),
+        }
+    }
+}
+
+pub fn clause_id_of_predicate(predicate: rustc_middle::ty::Predicate) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    // TODO: use stable hash here?
+    let mut s = DefaultHasher::new();
+    predicate.hash(&mut s);
+    s.finish()
+}
+
+/// Adapted from [rustc_trait_selection::traits::SelectionContext::select]:
+/// we want to preserve the nested obligations to resolve them afterwards.
+///
+/// Example:
+/// ========
+/// ```text
+/// struct Wrapper<T> {
+///    x: T,
+/// }
+///
+/// impl<T: ToU64> ToU64 for Wrapper<T> {
+///     fn to_u64(self) -> u64 {
+///         self.x.to_u64()
+///     }
+/// }
+///
+/// fn h(x: Wrapper<u64>) -> u64 {
+///     x.to_u64()
+/// }
+/// ```
+///
+/// When resolving the trait for `x.to_u64()` in `h`, we get that it uses the
+/// implementation for `Wrapper`. But we also need to know the obligation generated
+/// for `Wrapper` (in this case: `u64 : ToU64`) and resolve it.
+///
+/// TODO: returns an Option for now, `None` means we hit the indexing
+/// bug (see https://github.com/rust-lang/rust/issues/112242).
+#[tracing::instrument(level = "trace", skip(s))]
+pub fn select_trait_candidate<'tcx, S: BaseState<'tcx>>(
+    s: &S,
+    param_env: rustc_middle::ty::ParamEnv<'tcx>,
+    trait_ref: rustc_middle::ty::PolyTraitRef<'tcx>,
+) -> Option<rustc_trait_selection::traits::Selection<'tcx>> {
+    use rustc_infer::infer::TyCtxtInferExt;
+    use rustc_middle::traits::CodegenObligationError;
+    use rustc_trait_selection::traits::{
+        Obligation, ObligationCause, SelectionContext, Unimplemented,
+    };
+    let tcx = s.base().tcx;
+
+    // We expect the input to be fully normalized.
+    debug_assert_eq!(
+        trait_ref,
+        tcx.normalize_erasing_regions(param_env, trait_ref)
+    );
+
+    // Do the initial selection for the obligation. This yields the
+    // shallow result we are looking for -- that is, what specific impl.
+    let infcx = tcx.infer_ctxt().ignoring_regions().build();
+    let mut selcx = SelectionContext::new(&infcx);
+
+    let obligation_cause = ObligationCause::dummy();
+    let obligation = Obligation::new(tcx, obligation_cause, param_env, trait_ref);
+
+    if format!("{:#?}", obligation) == "Obligation(predicate=Binder(TraitPredicate(<_ as marker::Sized>, polarity:Positive), []), depth=0)" {
+        let tr = trait_ref.skip_binder();
+        let ty = tr.self_ty();
+        eprintln!("span={:#?}", s.base().opt_def_id.map(|did| tcx.def_span(did)));
+        eprintln!("obligation={:#?}", obligation);
+        eprintln!("ty={}", match ty.kind() {
+            rustc_middle::ty::Infer(var) => format!("Infer({:#?})", match var {
+                rustc_middle::ty::InferTy::TyVar(payload) => format!("TyVar({:?})", payload),
+                rustc_middle::ty::InferTy::IntVar(payload) => format!("IntVar({:?})", payload),
+                rustc_middle::ty::InferTy::FloatVar(payload) => format!("FloatVar({:?})", payload),
+                rustc_middle::ty::InferTy::FreshTy(payload) => format!("FreshTy({:?})", payload),
+                rustc_middle::ty::InferTy::FreshIntTy(payload) => format!("FreshIntTy({:?})", payload),
+                rustc_middle::ty::InferTy::FreshFloatTy(payload) => format!("FreshFloatTy({:?})", payload),
+            }),
+            k => format!("{:?}", k)
+        });
+    }
+    let selection = {
+        use std::panic;
+        panic::set_hook(Box::new(|_info| {}));
+        let result = panic::catch_unwind(panic::AssertUnwindSafe(|| selcx.select(&obligation)));
+        let _ = panic::take_hook();
+        result
+    };
+    match selection {
+        Ok(Ok(Some(selection))) => Some(infcx.resolve_vars_if_possible(selection)),
+        Ok(error) => fatal!(
+            s,
+            "Cannot hanlde error `{:?}` selecting `{:?}`",
+            error,
+            trait_ref
+        ),
+        Err(_) => None,
+    }
+}

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -320,10 +320,7 @@ pub fn select_trait_candidate<'tcx, S: UnderOwnerState<'tcx>>(
     trait_ref: rustc_middle::ty::PolyTraitRef<'tcx>,
 ) -> Option<rustc_trait_selection::traits::Selection<'tcx>> {
     use rustc_infer::infer::TyCtxtInferExt;
-    use rustc_middle::traits::CodegenObligationError;
-    use rustc_trait_selection::traits::{
-        Obligation, ObligationCause, SelectionContext, Unimplemented,
-    };
+    use rustc_trait_selection::traits::{Obligation, ObligationCause, SelectionContext};
     let tcx = s.base().tcx;
     let trait_ref = tcx
         .try_normalize_erasing_regions(param_env, trait_ref)

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -205,7 +205,7 @@ impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
             ImplSource::Param(nested, _constness) => {
                 use search_clause::TraitPredicateExt;
                 let tcx = s.base().tcx;
-                let predicates = &tcx.predicates_defined_on_or_above(s.owner_id().to_def_id());
+                let predicates = &tcx.predicates_defined_on_or_above(s.owner_id());
                 let Some((predicate, path)) = predicates.into_iter().find_map(|(predicate, _)| {
                     predicate
                         .to_opt_poly_trait_pred()

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -2319,12 +2319,7 @@ pub struct AnonConst<Body: IsBody> {
     pub hir_id: HirId,
     pub def_id: GlobalIdent,
     #[map({
-        body_from_id::<Body, _>(*x, &State {
-            thir: (),
-            owner_id: hir_id.owner,
-            base: s.base(),
-            mir: (),
-        })
+        body_from_id::<Body, _>(*x, &with_owner_id(s.base(), (), (), hir_id.owner))
     })]
     pub body: Body,
 }
@@ -3033,15 +3028,7 @@ pub struct Item<Body: IsBody> {
     pub span: Span,
     pub vis_span: Span,
     #[map({
-        self.kind.sinto(&State {
-            base: crate::state::Base {
-                opt_def_id: Some(self.owner_id.to_def_id()),
-                ..state.base()
-            },
-            thir: (),
-            mir: (),
-            owner_id: self.owner_id,
-        })
+        self.kind.sinto(&with_owner_id(state.base(), (), (), self.owner_id))
     })]
     pub kind: ItemKind<Body>,
     #[map(ItemAttributes::from_owner_id(state, *owner_id))]

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -61,7 +61,7 @@ impl std::convert::From<DefId> for Path {
 }
 
 pub type GlobalIdent = DefId;
-impl<'tcx, S: BaseState<'tcx>> SInto<S, GlobalIdent> for rustc_hir::def_id::LocalDefId {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, GlobalIdent> for rustc_hir::def_id::LocalDefId {
     fn sinto(&self, st: &S) -> DefId {
         self.to_def_id().sinto(st)
     }
@@ -100,7 +100,7 @@ pub enum DefPathItem {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'slt, S: BaseState<'slt> + HasThir<'slt>>, from: rustc_middle::thir::LintLevel, state: S as gstate)]
+#[args(<'slt, S: UnderOwnerState<'slt> + HasThir<'slt>>, from: rustc_middle::thir::LintLevel, state: S as gstate)]
 pub enum LintLevel {
     Inherited,
     Explicit(HirId),
@@ -118,7 +118,7 @@ pub enum AttrStyle {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'slt, S: BaseState<'slt>>, from: rustc_ast::ast::Attribute, state: S as gstate)]
+#[args(<'slt, S: UnderOwnerState<'slt>>, from: rustc_ast::ast::Attribute, state: S as gstate)]
 pub struct Attribute {
     pub kind: AttrKind,
     #[map(x.as_usize())]
@@ -139,14 +139,14 @@ pub struct Decorated<T> {
 }
 
 #[derive(AdtInto, Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'slt, S: BaseState<'slt>>, from: rustc_middle::mir::UnOp, state: S as _s)]
+#[args(<'slt, S: UnderOwnerState<'slt>>, from: rustc_middle::mir::UnOp, state: S as _s)]
 pub enum UnOp {
     Not,
     Neg,
 }
 
 #[derive(AdtInto, Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'slt, S: BaseState<'slt>>, from: rustc_middle::mir::BinOp, state: S as _s)]
+#[args(<'slt, S: UnderOwnerState<'slt>>, from: rustc_middle::mir::BinOp, state: S as _s)]
 pub enum BinOp {
     Add,
     Sub,
@@ -171,7 +171,7 @@ pub type Pat = Decorated<PatKind>;
 pub type Expr = Decorated<ExprKind>;
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasThir<'tcx>>, from: rustc_middle::middle::region::ScopeData, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_middle::middle::region::ScopeData, state: S as gstate)]
 pub enum ScopeData {
     Node,
     CallSite,
@@ -182,13 +182,15 @@ pub enum ScopeData {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasThir<'tcx>>, from: rustc_middle::middle::region::Scope, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_middle::middle::region::Scope, state: S as gstate)]
 pub struct Scope {
     pub id: ItemLocalId,
     pub data: ScopeData,
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, ConstantExpr> for rustc_middle::mir::ConstantKind<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, ConstantExpr>
+    for rustc_middle::mir::ConstantKind<'tcx>
+{
     fn sinto(&self, s: &S) -> ConstantExpr {
         use rustc_middle::mir::ConstantKind;
         let tcx = s.base().tcx;
@@ -220,13 +222,13 @@ impl<S> SInto<S, u64> for rustc_middle::mir::interpret::AllocId {
     }
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, Box<Ty>> for rustc_middle::ty::Ty<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Box<Ty>> for rustc_middle::ty::Ty<'tcx> {
     fn sinto(&self, s: &S) -> Box<Ty> {
         Box::new(self.sinto(s))
     }
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, Ty> for rustc_middle::ty::Ty<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Ty> for rustc_middle::ty::Ty<'tcx> {
     fn sinto(&self, s: &S) -> Ty {
         self.kind().sinto(s)
     }
@@ -252,7 +254,7 @@ impl<'tcx, S: BaseState<'tcx>> SInto<S, DefId> for rustc_hir::hir_id::OwnerId {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx> + HasThir<'tcx>>, from: rustc_ast::ast::LitFloatType, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_ast::ast::LitFloatType, state: S as gstate)]
 pub enum LitFloatType {
     Suffixed(FloatTy),
     Unsuffixed,
@@ -267,7 +269,7 @@ pub enum Movability {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::infer::canonical::CanonicalTyVarKind, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::infer::canonical::CanonicalTyVarKind, state: S as gstate)]
 pub enum CanonicalTyVarKind {
     General(UniverseIndex),
     Int,
@@ -277,7 +279,7 @@ pub enum CanonicalTyVarKind {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::ParamTy, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::ParamTy, state: S as gstate)]
 pub struct ParamTy {
     pub index: u32,
     pub name: Symbol,
@@ -304,7 +306,7 @@ pub enum DynKind {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::BoundTyKind, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::BoundTyKind, state: S as gstate)]
 pub enum BoundTyKind {
     Anon,
     Param(DefId, Symbol),
@@ -313,7 +315,7 @@ pub enum BoundTyKind {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::BoundTy, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::BoundTy, state: S as gstate)]
 pub struct BoundTy {
     pub var: BoundVar,
     pub kind: BoundTyKind,
@@ -322,7 +324,7 @@ pub struct BoundTy {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::BoundRegionKind, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::BoundRegionKind, state: S as gstate)]
 pub enum BoundRegionKind {
     BrAnon(Option<Span>),
     BrNamed(DefId, Symbol),
@@ -332,7 +334,7 @@ pub enum BoundRegionKind {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::BoundRegion, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::BoundRegion, state: S as gstate)]
 pub struct BoundRegion {
     pub var: BoundVar,
     pub kind: BoundRegionKind,
@@ -350,7 +352,7 @@ pub struct Placeholder<T> {
     pub bound: T,
 }
 
-impl<'tcx, S: BaseState<'tcx>, T: SInto<S, U>, U> SInto<S, Placeholder<U>>
+impl<'tcx, S: UnderOwnerState<'tcx>, T: SInto<S, U>, U> SInto<S, Placeholder<U>>
     for rustc_middle::ty::Placeholder<T>
 {
     fn sinto(&self, s: &S) -> Placeholder<U> {
@@ -369,7 +371,7 @@ pub struct Canonical<T> {
 }
 pub type CanonicalUserType = Canonical<UserType>;
 
-impl<'tcx, S: BaseState<'tcx>, T: SInto<S, U>, U> SInto<S, Canonical<U>>
+impl<'tcx, S: UnderOwnerState<'tcx>, T: SInto<S, U>, U> SInto<S, Canonical<U>>
     for rustc_middle::infer::canonical::Canonical<'tcx, T>
 {
     fn sinto(&self, s: &S) -> Canonical<U> {
@@ -382,7 +384,7 @@ impl<'tcx, S: BaseState<'tcx>, T: SInto<S, U>, U> SInto<S, Canonical<U>>
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::infer::canonical::CanonicalVarKind<'tcx>, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::infer::canonical::CanonicalVarKind<'tcx>, state: S as gstate)]
 pub enum CanonicalVarInfo {
     Ty(CanonicalTyVarKind),
     PlaceholderTy(PlaceholderType),
@@ -393,21 +395,21 @@ pub enum CanonicalVarInfo {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::subst::UserSelfTy<'tcx>, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::subst::UserSelfTy<'tcx>, state: S as gstate)]
 pub struct UserSelfTy {
     pub impl_def_id: DefId,
     pub self_ty: Ty,
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::subst::UserSubsts<'tcx>, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::subst::UserSubsts<'tcx>, state: S as gstate)]
 pub struct UserSubsts {
     pub substs: Vec<GenericArg>,
     pub user_self_ty: Option<UserSelfTy>,
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::UserType<'tcx>, state: S as _s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::UserType<'tcx>, state: S as _s)]
 pub enum UserType {
     // TODO: for now, we don't use user types at all.
     // We disable it for now, since it cause the following to fail:
@@ -443,7 +445,7 @@ pub enum CtorKind {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::VariantDiscr, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::VariantDiscr, state: S as gstate)]
 pub enum VariantDiscr {
     Explicit(DefId),
     Relative(u32),
@@ -474,7 +476,7 @@ pub struct FieldDef {
     pub span: Span,
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, FieldDef> for rustc_middle::ty::FieldDef {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, FieldDef> for rustc_middle::ty::FieldDef {
     fn sinto(&self, s: &S) -> FieldDef {
         let tcx = s.base().tcx;
         let ty = {
@@ -503,7 +505,7 @@ impl<'tcx, S: BaseState<'tcx>> SInto<S, FieldDef> for rustc_middle::ty::FieldDef
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::VariantDef, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::VariantDef, state: S as s)]
 pub struct VariantDef {
     pub def_id: DefId,
     pub ctor: Option<(CtorKind, DefId)>,
@@ -518,7 +520,7 @@ pub struct VariantDef {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::EarlyBoundRegion, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::EarlyBoundRegion, state: S as gstate)]
 pub struct EarlyBoundRegion {
     pub def_id: DefId,
     pub index: u32,
@@ -528,7 +530,7 @@ pub struct EarlyBoundRegion {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::FreeRegion, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::FreeRegion, state: S as gstate)]
 pub struct FreeRegion {
     pub scope: DefId,
     pub bound_region: BoundRegionKind,
@@ -552,7 +554,7 @@ impl<S> SInto<S, RegionVid> for rustc_middle::ty::RegionVid {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::RegionKind<'tcx>, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::RegionKind<'tcx>, state: S as gstate)]
 pub enum RegionKind {
     ReEarlyBound(EarlyBoundRegion),
     ReLateBound(DebruijnIndex, BoundRegion),
@@ -567,7 +569,7 @@ pub enum RegionKind {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::Region<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::Region<'tcx>, state: S as s)]
 pub struct Region {
     #[value(self.kind().sinto(s))]
     pub kind: RegionKind,
@@ -576,20 +578,20 @@ pub struct Region {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::subst::GenericArgKind<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::subst::GenericArgKind<'tcx>, state: S as s)]
 pub enum GenericArg {
     Lifetime(Region),
     Type(Ty),
     Const(ConstantExpr),
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, GenericArg> for rustc_middle::ty::GenericArg<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, GenericArg> for rustc_middle::ty::GenericArg<'tcx> {
     fn sinto(&self, s: &S) -> GenericArg {
         self.unpack().sinto(s)
     }
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, Vec<GenericArg>>
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Vec<GenericArg>>
     for rustc_middle::ty::subst::SubstsRef<'tcx>
 {
     fn sinto(&self, s: &S) -> Vec<GenericArg> {
@@ -598,7 +600,7 @@ impl<'tcx, S: BaseState<'tcx>> SInto<S, Vec<GenericArg>>
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasThir<'tcx>>, from: rustc_ast::ast::LitIntType, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_ast::ast::LitIntType, state: S as gstate)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -757,7 +759,7 @@ pub struct LocalIdent {
     pub id: HirId,
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, LocalIdent> for rustc_middle::thir::LocalVarId {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, LocalIdent> for rustc_middle::thir::LocalVarId {
     fn sinto(&self, s: &S) -> LocalIdent {
         LocalIdent {
             name: s
@@ -779,7 +781,7 @@ pub struct Spanned<T> {
     pub node: T,
     pub span: Span,
 }
-impl<'s, S: BaseState<'s>, T: SInto<S, U>, U> SInto<S, Spanned<U>>
+impl<'s, S: UnderOwnerState<'s>, T: SInto<S, U>, U> SInto<S, Spanned<U>>
     for rustc_span::source_map::Spanned<T>
 {
     fn sinto<'a>(&self, s: &S) -> Spanned<U> {
@@ -790,7 +792,7 @@ impl<'s, S: BaseState<'s>, T: SInto<S, U>, U> SInto<S, Spanned<U>>
     }
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, String> for PathBuf {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, String> for PathBuf {
     fn sinto(&self, _: &S) -> String {
         self.as_path().display().to_string()
     }
@@ -884,7 +886,7 @@ pub struct AliasTy {
     pub def_id: DefId,
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, AliasTy> for rustc_middle::ty::AliasTy<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, AliasTy> for rustc_middle::ty::AliasTy<'tcx> {
     fn sinto(&self, s: &S) -> AliasTy {
         let tcx = s.base().tcx;
         use rustc_hir::def::DefKind::*;
@@ -944,7 +946,7 @@ pub enum Delimiter {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_ast::tokenstream::TokenTree, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::tokenstream::TokenTree, state: S as s)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -954,7 +956,7 @@ pub enum TokenTree {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_ast::tokenstream::Spacing, state: S as _s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::tokenstream::Spacing, state: S as _s)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -982,7 +984,7 @@ pub enum BinOpToken {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_ast::token::TokenKind, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::token::TokenKind, state: S as gstate)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -1029,7 +1031,7 @@ pub enum TokenKind {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_ast::token::Token, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::token::Token, state: S as gstate)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -1050,7 +1052,7 @@ pub struct DelimArgs {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_ast::ast::MacCall, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::ast::MacCall, state: S as gstate)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -1079,7 +1081,7 @@ impl<'tcx, S: ExprState<'tcx>> SInto<S, Stmt> for rustc_middle::thir::StmtId {
     }
 }
 
-pub trait ExprState<'tcx> = BaseState<'tcx> + HasThir<'tcx> + HasOwnerId;
+pub trait ExprState<'tcx> = UnderOwnerState<'tcx> + HasThir<'tcx>;
 
 impl<'tcx, S: ExprState<'tcx>> SInto<S, Expr> for rustc_middle::thir::Expr<'tcx> {
     fn sinto(&self, s: &S) -> Expr {
@@ -1353,7 +1355,7 @@ impl ToString for UintTy {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::TypeAndMut<'tcx>, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::TypeAndMut<'tcx>, state: S as gstate)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -1375,7 +1377,7 @@ pub enum ArrowKind {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::GenericParamDef, state: S as state)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::GenericParamDef, state: S as state)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct GenericParamDef {
     pub name: Symbol,
@@ -1386,7 +1388,7 @@ pub struct GenericParamDef {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::GenericParamDefKind, state: S as state)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::GenericParamDefKind, state: S as state)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum GenericParamDefKind {
     Lifetime,
@@ -1395,7 +1397,7 @@ pub enum GenericParamDefKind {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::Generics, state: S as state)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::Generics, state: S as state)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct TyGenerics {
     pub parent: Option<DefId>,
@@ -1418,7 +1420,7 @@ pub enum AliasKind {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::TyKind<'tcx>, state: S as state)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::TyKind<'tcx>, state: S as state)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -1506,7 +1508,7 @@ pub enum Variance {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::CanonicalUserTypeAnnotation<'tcx>, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::CanonicalUserTypeAnnotation<'tcx>, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CanonicalUserTypeAnnotation {
     pub user_ty: CanonicalUserType,
@@ -1515,7 +1517,7 @@ pub struct CanonicalUserTypeAnnotation {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasThir<'tcx>>, from: rustc_middle::thir::Ascription<'tcx>, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_middle::thir::Ascription<'tcx>, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Ascription {
     pub annotation: CanonicalUserTypeAnnotation,
@@ -1531,7 +1533,7 @@ pub enum RangeEnd {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasThir<'tcx>>, from: rustc_middle::thir::PatRange<'tcx>, state: S as state)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_middle::thir::PatRange<'tcx>, state: S as state)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct PatRange {
     pub lo: ConstantExpr,
@@ -1540,7 +1542,7 @@ pub struct PatRange {
 }
 
 #[derive(AdtInto, Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::AdtKind, state: S as _s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::AdtKind, state: S as _s)]
 pub enum AdtKind {
     Struct,
     Union,
@@ -1558,7 +1560,7 @@ pub struct AdtDef {
     pub repr: ReprOptions,
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, AdtDef> for rustc_middle::ty::AdtDef<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, AdtDef> for rustc_middle::ty::AdtDef<'tcx> {
     fn sinto(&self, s: &S) -> AdtDef {
         AdtDef {
             did: self.did().sinto(s),
@@ -1749,7 +1751,7 @@ pub enum StrStyle {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasThir<'tcx>>, from: rustc_ast::ast::LitKind, state: S as gstate)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_ast::ast::LitKind, state: S as gstate)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2171,7 +2173,7 @@ impl<'tcx> ExprKindExt<'tcx> for rustc_middle::thir::Expr<'tcx> {
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::FnSig<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::FnSig<'tcx>, state: S as s)]
 pub struct TyFnSig {
     #[value(self.inputs().sinto(s))]
     pub inputs: Vec<Ty>,
@@ -2194,7 +2196,7 @@ pub struct FnDef<Body: IsBody> {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::FnDecl<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::FnDecl<'tcx>, state: S as tcx)]
 pub struct FnDecl {
     pub inputs: Vec<Ty>,
     pub output: FnRetTy,
@@ -2204,7 +2206,7 @@ pub struct FnDecl {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::FnSig<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::FnSig<'tcx>, state: S as tcx)]
 pub struct FnSig {
     pub header: FnHeader,
     pub decl: FnDecl,
@@ -2222,7 +2224,7 @@ pub struct FnHeader {
 
 pub type ThirBody = Expr;
 
-impl<'x, 'tcx, S: BaseState<'tcx> + HasOwnerId> SInto<S, Ty> for rustc_hir::Ty<'x> {
+impl<'x, 'tcx, S: UnderOwnerState<'tcx>> SInto<S, Ty> for rustc_hir::Ty<'x> {
     fn sinto(self: &rustc_hir::Ty<'x>, s: &S) -> Ty {
         let ctx = rustc_hir_analysis::collect::ItemCtxt::new(s.base().tcx, s.owner_id().def_id);
         ctx.to_ty(self).sinto(s)
@@ -2255,7 +2257,7 @@ pub enum Defaultness {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_hir::ImplPolarity, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::ImplPolarity, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum ImplPolarity {
     Positive,
@@ -2271,7 +2273,7 @@ pub enum Constness {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::Generics<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::Generics<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Generics<Body: IsBody> {
     pub params: Vec<GenericParam<Body>>,
@@ -2282,7 +2284,7 @@ pub struct Generics<Body: IsBody> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::WherePredicate<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::WherePredicate<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum WherePredicate<Body: IsBody> {
     BoundPredicate(WhereBoundPredicate<Body>),
@@ -2290,7 +2292,7 @@ pub enum WherePredicate<Body: IsBody> {
     EqPredicate(WhereEqPredicate),
 }
 
-impl<'tcx, S: BaseState<'tcx> + HasOwnerId, Body: IsBody> SInto<S, ImplItem<Body>>
+impl<'tcx, S: UnderOwnerState<'tcx>, Body: IsBody> SInto<S, ImplItem<Body>>
     for rustc_hir::ImplItemRef
 {
     fn sinto(&self, s: &S) -> ImplItem<Body> {
@@ -2314,7 +2316,7 @@ pub enum LifetimeParamKind {
     Error,
 }
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_hir::AnonConst, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::AnonConst, state: S as s)]
 pub struct AnonConst<Body: IsBody> {
     pub hir_id: HirId,
     pub def_id: GlobalIdent,
@@ -2325,7 +2327,7 @@ pub struct AnonConst<Body: IsBody> {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::GenericParamKind<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::GenericParamKind<'tcx>, state: S as tcx)]
 pub enum GenericParamKind<Body: IsBody> {
     Lifetime {
         kind: LifetimeParamKind,
@@ -2342,7 +2344,7 @@ pub enum GenericParamKind<Body: IsBody> {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::GenericParam<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::GenericParam<'tcx>, state: S as s)]
 pub struct GenericParam<Body: IsBody> {
     pub hir_id: HirId,
     pub def_id: GlobalIdent,
@@ -2367,7 +2369,7 @@ pub struct GenericParam<Body: IsBody> {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::ImplItem<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ImplItem<'tcx>, state: S as s)]
 pub struct ImplItem<Body: IsBody> {
     pub ident: Ident,
     pub owner_id: DefId,
@@ -2381,7 +2383,7 @@ pub struct ImplItem<Body: IsBody> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::ImplItemKind<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ImplItemKind<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum ImplItemKind<Body: IsBody> {
     Const(Ty, Body),
@@ -2393,7 +2395,7 @@ pub enum ImplItemKind<Body: IsBody> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_hir::AssocItemKind, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::AssocItemKind, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum AssocItemKind {
     Const,
@@ -2414,7 +2416,7 @@ impl<
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::Impl<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::Impl<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Impl<Body: IsBody> {
     pub unsafety: Unsafety,
@@ -2440,7 +2442,7 @@ pub enum IsAsync {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::FnRetTy<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::FnRetTy<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum FnRetTy {
     DefaultReturn(Span),
@@ -2448,7 +2450,7 @@ pub enum FnRetTy {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::VariantData<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::VariantData<'tcx>, state: S as tcx)]
 pub enum VariantData {
     Struct(Vec<HirFieldDef>, bool),
     Tuple(Vec<HirFieldDef>, HirId, GlobalIdent),
@@ -2456,7 +2458,7 @@ pub enum VariantData {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::FieldDef<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::FieldDef<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct HirFieldDef {
     pub span: Span,
@@ -2470,7 +2472,7 @@ pub struct HirFieldDef {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::Variant<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::Variant<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Variant<Body: IsBody> {
     pub ident: Ident,
@@ -2484,7 +2486,7 @@ pub struct Variant<Body: IsBody> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_hir::UsePath<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::UsePath<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UsePath {
     pub span: Span,
@@ -2505,7 +2507,7 @@ pub struct UsePath {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_hir::def::Res, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::def::Res, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum Res {
     Def(DefKind, DefId),
@@ -2548,7 +2550,7 @@ pub enum NonMacroAttrKind {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_hir::PathSegment<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::PathSegment<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct PathSegment {
     pub ident: Ident,
@@ -2560,7 +2562,7 @@ pub struct PathSegment {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::ItemKind<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ItemKind<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum ItemKind<Body: IsBody> {
     #[disable_mapping]
@@ -2601,7 +2603,7 @@ pub enum ItemKind<Body: IsBody> {
 pub type EnumDef<Body> = Vec<Variant<Body>>;
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::TraitItemKind<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::TraitItemKind<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum TraitItemKind<Body: IsBody> {
     Const(Ty, Option<Body>),
@@ -2626,7 +2628,7 @@ pub enum TraitItemKind<Body: IsBody> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::TraitItem<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::TraitItem<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct TraitItem<Body: IsBody> {
     pub ident: Ident,
@@ -2639,7 +2641,7 @@ pub struct TraitItem<Body: IsBody> {
     pub attributes: ItemAttributes,
 }
 
-impl<'tcx, S: BaseState<'tcx> + HasOwnerId, Body: IsBody> SInto<S, EnumDef<Body>>
+impl<'tcx, S: UnderOwnerState<'tcx>, Body: IsBody> SInto<S, EnumDef<Body>>
     for rustc_hir::EnumDef<'tcx>
 {
     fn sinto(&self, s: &S) -> EnumDef<Body> {
@@ -2647,7 +2649,7 @@ impl<'tcx, S: BaseState<'tcx> + HasOwnerId, Body: IsBody> SInto<S, EnumDef<Body>
     }
 }
 
-impl<'a, S: BaseState<'a> + HasOwnerId, Body: IsBody> SInto<S, TraitItem<Body>>
+impl<'a, S: UnderOwnerState<'a>, Body: IsBody> SInto<S, TraitItem<Body>>
     for rustc_hir::TraitItemRef
 {
     fn sinto(&self, s: &S) -> TraitItem<Body> {
@@ -2666,7 +2668,9 @@ impl<'a, S: BaseState<'a> + HasOwnerId, Body: IsBody> SInto<S, TraitItem<Body>>
     }
 }
 
-impl<'a, 'tcx, S: BaseState<'tcx>, Body: IsBody> SInto<S, Vec<Item<Body>>> for rustc_hir::Mod<'a> {
+impl<'a, 'tcx, S: UnderOwnerState<'tcx>, Body: IsBody> SInto<S, Vec<Item<Body>>>
+    for rustc_hir::Mod<'a>
+{
     fn sinto(&self, s: &S) -> Vec<Item<Body>> {
         inline_macro_invocations(self.item_ids.iter().copied(), s)
         // .iter()
@@ -2676,7 +2680,7 @@ impl<'a, 'tcx, S: BaseState<'tcx>, Body: IsBody> SInto<S, Vec<Item<Body>>> for r
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::ForeignItemKind<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ForeignItemKind<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum ForeignItemKind<Body: IsBody> {
     Fn(FnDecl, Vec<Ident>, Generics<Body>),
@@ -2685,7 +2689,7 @@ pub enum ForeignItemKind<Body: IsBody> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::ForeignItem<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ForeignItem<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ForeignItem<Body: IsBody> {
     pub ident: Ident,
@@ -2695,7 +2699,7 @@ pub struct ForeignItem<Body: IsBody> {
     pub vis_span: Span,
 }
 
-impl<'a, S: BaseState<'a> + HasOwnerId, Body: IsBody> SInto<S, ForeignItem<Body>>
+impl<'a, S: UnderOwnerState<'a>, Body: IsBody> SInto<S, ForeignItem<Body>>
     for rustc_hir::ForeignItemRef
 {
     fn sinto(&self, s: &S) -> ForeignItem<Body> {
@@ -2705,7 +2709,7 @@ impl<'a, S: BaseState<'a> + HasOwnerId, Body: IsBody> SInto<S, ForeignItem<Body>
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::OpaqueTy<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::OpaqueTy<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct OpaqueTy<Body: IsBody> {
     pub generics: Generics<Body>,
@@ -2715,7 +2719,7 @@ pub struct OpaqueTy<Body: IsBody> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_hir::LifetimeName, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::LifetimeName, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum LifetimeName {
     Param(GlobalIdent),
@@ -2726,7 +2730,7 @@ pub enum LifetimeName {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_hir::Lifetime, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::Lifetime, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Lifetime {
     pub hir_id: HirId,
@@ -2735,7 +2739,7 @@ pub struct Lifetime {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::TraitRef<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::TraitRef<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2746,7 +2750,7 @@ pub struct TraitRef {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::TraitPredicate<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::TraitPredicate<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2768,7 +2772,7 @@ pub struct OutlivesPredicate<A, B> {
     pub rhs: B,
 }
 
-impl<'tcx, S: BaseState<'tcx>, A1, A2, B1, B2> SInto<S, OutlivesPredicate<A2, B2>>
+impl<'tcx, S: UnderOwnerState<'tcx>, A1, A2, B1, B2> SInto<S, OutlivesPredicate<A2, B2>>
     for rustc_middle::ty::OutlivesPredicate<A1, B1>
 where
     A1: SInto<S, A2>,
@@ -2793,7 +2797,7 @@ pub enum Term {
     Const(ConstantExpr),
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, Term> for rustc_middle::ty::Term<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Term> for rustc_middle::ty::Term<'tcx> {
     fn sinto(&self, s: &S) -> Term {
         use rustc_middle::ty::TermKind;
         match self.unpack() {
@@ -2804,7 +2808,7 @@ impl<'tcx, S: BaseState<'tcx>> SInto<S, Term> for rustc_middle::ty::Term<'tcx> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::ProjectionPredicate<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::ProjectionPredicate<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2814,7 +2818,7 @@ pub struct ProjectionPredicate {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::Clause<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::Clause<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2834,7 +2838,7 @@ pub struct Clause {
     pub id: u64,
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, Clause> for rustc_middle::ty::Clause<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Clause> for rustc_middle::ty::Clause<'tcx> {
     fn sinto(&self, s: &S) -> Clause {
         use rustc_middle::ty::ToPredicate;
         Clause {
@@ -2845,7 +2849,7 @@ impl<'tcx, S: BaseState<'tcx>> SInto<S, Clause> for rustc_middle::ty::Clause<'tc
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::BoundVariableKind, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::BoundVariableKind, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2864,7 +2868,7 @@ pub struct Binder<T> {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::GenericPredicates<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::GenericPredicates<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2875,7 +2879,8 @@ pub struct GenericPredicates {
 
 pub type Predicate = Binder<PredicateKind>;
 
-impl<'tcx, S: BaseState<'tcx>, T1, T2> SInto<S, Binder<T2>> for rustc_middle::ty::Binder<'tcx, T1>
+impl<'tcx, S: UnderOwnerState<'tcx>, T1, T2> SInto<S, Binder<T2>>
+    for rustc_middle::ty::Binder<'tcx, T1>
 where
     T1: SInto<S, T2> + Clone + rustc_middle::ty::TypeFoldable<rustc_middle::ty::TyCtxt<'tcx>>,
 {
@@ -2886,14 +2891,14 @@ where
     }
 }
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, Predicate> for rustc_middle::ty::Predicate<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Predicate> for rustc_middle::ty::Predicate<'tcx> {
     fn sinto(&self, s: &S) -> Predicate {
         self.kind().sinto(s)
     }
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::SubtypePredicate<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::SubtypePredicate<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2904,7 +2909,7 @@ pub struct SubtypePredicate {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::CoercePredicate<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::CoercePredicate<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2914,7 +2919,7 @@ pub struct CoercePredicate {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::AliasRelationDirection, state: S as _tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::AliasRelationDirection, state: S as _tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2924,7 +2929,7 @@ pub enum AliasRelationDirection {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::ClosureKind, state: S as _tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::ClosureKind, state: S as _tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2935,7 +2940,7 @@ pub enum ClosureKind {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::PredicateKind<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::PredicateKind<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2955,9 +2960,7 @@ pub enum PredicateKind {
 
 type GenericBounds = Vec<PredicateKind>;
 
-impl<'tcx, S: BaseState<'tcx> + HasOwnerId> SInto<S, GenericBounds>
-    for rustc_hir::GenericBounds<'tcx>
-{
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, GenericBounds> for rustc_hir::GenericBounds<'tcx> {
     fn sinto(&self, s: &S) -> GenericBounds {
         let tcx = s.base().tcx;
 
@@ -2998,7 +3001,7 @@ impl<'tcx, S: BaseState<'tcx> + HasOwnerId> SInto<S, GenericBounds>
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_hir::OpaqueTyOrigin, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::OpaqueTyOrigin, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum OpaqueTyOrigin {
     FnReturn(GlobalIdent),
@@ -3054,14 +3057,14 @@ impl<'tcx, S: BaseState<'tcx>, Body: IsBody> SInto<S, Item<Body>> for rustc_hir:
 
 pub type Ident = (Symbol, Span);
 
-impl<'tcx, S: BaseState<'tcx>> SInto<S, Ident> for rustc_span::symbol::Ident {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Ident> for rustc_span::symbol::Ident {
     fn sinto(&self, s: &S) -> Ident {
         (self.name.sinto(s), self.span.sinto(s))
     }
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx> + HasOwnerId>, from: rustc_hir::WhereBoundPredicate<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::WhereBoundPredicate<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct WhereBoundPredicate<Body: IsBody> {
     pub hir_id: HirId,
@@ -3082,7 +3085,7 @@ pub enum PredicateOrigin {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::AssocItem, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::AssocItem, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -3097,7 +3100,7 @@ pub struct AssocItem {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::ImplTraitInTraitData, state: S as _tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::ImplTraitInTraitData, state: S as _tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -2123,6 +2123,14 @@ pub enum ExprKind {
         def_id: GlobalIdent,
         substs: Vec<GenericArg>,
         user_ty: Option<CanonicalUserType>,
+        #[not_in_source]
+        #[value({
+            let tcx = gstate.base().tcx;
+            tcx.opt_associated_item(*def_id).as_ref().and_then(|assoc| {
+                poly_trait_ref(gstate, assoc, substs)
+            }).map(|poly_trait_ref| poly_trait_ref.impl_expr(gstate, tcx.param_env(gstate.owner_id())))
+        })]
+        r#impl: Option<ImplExpr>,
     },
     ConstParam {
         param: ParamConst,

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -3077,7 +3077,9 @@ pub enum PredicateOrigin {
 
 #[derive(AdtInto)]
 #[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::AssocItem, state: S as tcx)]
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
+)]
 pub struct AssocItem {
     pub def_id: DefId,
     pub name: Symbol,
@@ -3090,7 +3092,9 @@ pub struct AssocItem {
 
 #[derive(AdtInto)]
 #[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::ImplTraitInTraitData, state: S as _tcx)]
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
+)]
 pub enum ImplTraitInTraitData {
     Trait {
         fn_def_id: DefId,
@@ -3103,7 +3107,9 @@ pub enum ImplTraitInTraitData {
 
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_middle::ty::AssocItemContainer, state: S as _tcx)]
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
+)]
 pub enum AssocItemContainer {
     TraitContainer,
     ImplContainer,
@@ -3111,7 +3117,9 @@ pub enum AssocItemContainer {
 
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_middle::ty::AssocKind, state: S as _tcx)]
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
+)]
 pub enum AssocKind {
     Const,
     Fn,

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -2624,10 +2624,10 @@ pub enum TraitItemKind<Body: IsBody> {
     RequiredFn(FnSig, Vec<Ident>),
     #[custom_arm(
         rustc_hir::TraitItemKind::Fn(sig, rustc_hir::TraitFn::Provided(body)) => {
-            TraitItemKind::ProvidedFn(make_fn_def::<Body, _>(sig, body, tcx))
+            TraitItemKind::ProvidedFn(sig.sinto(tcx), make_fn_def::<Body, _>(sig, body, tcx))
         }
     )]
-    ProvidedFn(FnDef<Body>),
+    ProvidedFn(FnSig, FnDef<Body>),
     #[custom_arm(
         rustc_hir::TraitItemKind::Type(b, ty) => {
             TraitItemKind::Type(b.sinto(tcx), ty.map(|t| t.sinto(tcx)))

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -9,14 +9,14 @@ pub enum MirPhase {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::mir::SourceInfo, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::mir::SourceInfo, state: S as s)]
 pub struct SourceInfo {
     pub span: Span,
     pub scope: SourceScope,
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::mir::LocalDecl<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::mir::LocalDecl<'tcx>, state: S as s)]
 pub struct LocalDecl {
     pub mutability: Mutability,
     pub local_info: ClearCrossCrate<LocalInfo>,
@@ -108,7 +108,7 @@ pub mod mir_kinds {
 pub use mir_kinds::IsMirKind;
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::mir::Constant<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::mir::Constant<'tcx>, state: S as s)]
 pub struct Constant {
     pub span: Span,
     pub user_ty: Option<UserTypeAnnotationIndex>,
@@ -116,7 +116,7 @@ pub struct Constant {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Body<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Body<'tcx>, state: S as s)]
 pub struct MirBody<KIND> {
     #[map(x.clone().as_mut().sinto(s))]
     pub basic_blocks: BasicBlocks,
@@ -150,7 +150,7 @@ pub struct MirBody<KIND> {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::mir::SourceScopeData<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::mir::SourceScopeData<'tcx>, state: S as s)]
 pub struct SourceScopeData {
     pub span: Span,
     pub parent_scope: Option<SourceScope>,
@@ -160,21 +160,21 @@ pub struct SourceScopeData {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::ty::Instance<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::Instance<'tcx>, state: S as s)]
 pub struct Instance {
     pub def: InstanceDef,
     pub substs: Vec<GenericArg>,
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::mir::SourceScopeLocalData, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::mir::SourceScopeLocalData, state: S as s)]
 pub struct SourceScopeLocalData {
     pub lint_root: HirId,
     pub safety: Safety,
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx>>, from: rustc_middle::mir::Safety, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::mir::Safety, state: S as s)]
 pub enum Safety {
     Safe,
     BuiltinUnsafe,
@@ -183,7 +183,7 @@ pub enum Safety {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Operand<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Operand<'tcx>, state: S as s)]
 pub enum Operand {
     Copy(Place),
     Move(Place),
@@ -200,7 +200,7 @@ impl Operand {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Terminator<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Terminator<'tcx>, state: S as s)]
 pub struct Terminator {
     pub source_info: SourceInfo,
     pub kind: TerminatorKind,
@@ -211,7 +211,7 @@ pub struct Terminator {
 /// The [Operand] comes from a [TerminatorKind::Call].
 /// Only supports calls to top-level functions (which are considered as constants
 /// by rustc); doesn't support closures for now.
-fn get_function_from_operand<'tcx, S: BaseState<'tcx>>(
+fn get_function_from_operand<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     func: &rustc_middle::mir::Operand<'tcx>,
 ) -> (DefId, Vec<GenericArg>) {
@@ -266,7 +266,7 @@ pub struct ScalarInt {
 
 // TODO: naming conventions: is "translate" ok?
 /// Translate switch targets
-fn translate_switch_targets<'tcx, S: BaseState<'tcx>>(
+fn translate_switch_targets<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     switch_ty: &Ty,
     targets: &rustc_middle::mir::SwitchTargets,
@@ -333,7 +333,7 @@ pub enum SwitchTargets {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::TerminatorKind<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::TerminatorKind<'tcx>, state: S as s)]
 pub enum TerminatorKind {
     Goto {
         target: BasicBlock,
@@ -409,7 +409,7 @@ pub enum TerminatorKind {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Statement<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Statement<'tcx>, state: S as s)]
 pub struct Statement {
     pub source_info: SourceInfo,
     #[map(Box::new(x.sinto(s)))]
@@ -417,7 +417,7 @@ pub struct Statement {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::StatementKind<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::StatementKind<'tcx>, state: S as s)]
 pub enum StatementKind {
     Assign((Place, Rvalue)),
     FakeRead((FakeReadCause, Place)),
@@ -483,7 +483,9 @@ pub enum ProjectionElem {
 }
 
 // refactor
-impl<'tcx, S: BaseState<'tcx> + HasMir<'tcx>> SInto<S, Place> for rustc_middle::mir::Place<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>> SInto<S, Place>
+    for rustc_middle::mir::Place<'tcx>
+{
     #[tracing::instrument(level = "info", skip(s))]
     fn sinto(&self, s: &S) -> Place {
         let local_decl = &s.mir().local_decls[self.local];
@@ -609,7 +611,7 @@ impl<'tcx, S: BaseState<'tcx> + HasMir<'tcx>> SInto<S, Place> for rustc_middle::
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::AggregateKind<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::AggregateKind<'tcx>, state: S as s)]
 pub enum AggregateKind {
     Array(Ty),
     Tuple,
@@ -636,7 +638,7 @@ pub enum AggregateKind {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::CastKind, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::CastKind, state: S as s)]
 pub enum CastKind {
     PointerExposeAddress,
     PointerFromExposedAddress,
@@ -652,7 +654,7 @@ pub enum CastKind {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::NullOp<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::NullOp<'tcx>, state: S as s)]
 pub enum NullOp {
     SizeOf,
     AlignOf,
@@ -660,7 +662,7 @@ pub enum NullOp {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Rvalue<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::Rvalue<'tcx>, state: S as s)]
 pub enum Rvalue {
     Use(Operand),
     Repeat(Operand, ConstantExpr),
@@ -680,7 +682,7 @@ pub enum Rvalue {
 }
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[args(<'tcx, S: BaseState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::BasicBlockData<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> + HasMir<'tcx>>, from: rustc_middle::mir::BasicBlockData<'tcx>, state: S as s)]
 pub struct BasicBlockData {
     pub statements: Vec<Statement>,
     pub terminator: Option<Terminator>,

--- a/frontend/exporter/src/types/new.rs
+++ b/frontend/exporter/src/types/new.rs
@@ -21,7 +21,7 @@ lazy_static::lazy_static! {
 }
 
 impl ItemAttributes {
-    pub fn from_owner_id<'tcx, S: UnderOwnerState<'tcx>>(
+    pub fn from_owner_id<'tcx, S: BaseState<'tcx>>(
         s: &S,
         oid: rustc_hir::hir_id::OwnerId,
     ) -> ItemAttributes {
@@ -40,6 +40,16 @@ impl ItemAttributes {
                 .map(attrs_of)
                 .flatten()
                 .collect(),
+        }
+    }
+    pub fn from_def_id<'tcx, S: BaseState<'tcx>>(
+        s: &S,
+        did: rustc_span::def_id::DefId,
+    ) -> ItemAttributes {
+        if let Some(def_id) = did.as_local() {
+            Self::from_owner_id(s, rustc_hir::hir_id::OwnerId { def_id })
+        } else {
+            return ItemAttributes::new();
         }
     }
 }

--- a/frontend/exporter/src/types/new.rs
+++ b/frontend/exporter/src/types/new.rs
@@ -15,11 +15,19 @@ impl ItemAttributes {
     }
 }
 
+lazy_static::lazy_static! {
+    pub static ref CORE_EXTRACTION_MODE: bool =
+        std::env::var_os("HAX_CORE_EXTRACTION_MODE") == Some("on".into());
+}
+
 impl ItemAttributes {
     pub fn from_owner_id<'tcx, S: BaseState<'tcx>>(
         s: &S,
         oid: rustc_hir::hir_id::OwnerId,
     ) -> ItemAttributes {
+        if *CORE_EXTRACTION_MODE {
+            return ItemAttributes::new();
+        }
         use rustc_hir::hir_id::HirId;
         let tcx = s.base().tcx;
         let hir = tcx.hir();

--- a/frontend/exporter/src/types/new.rs
+++ b/frontend/exporter/src/types/new.rs
@@ -21,7 +21,7 @@ lazy_static::lazy_static! {
 }
 
 impl ItemAttributes {
-    pub fn from_owner_id<'tcx, S: BaseState<'tcx>>(
+    pub fn from_owner_id<'tcx, S: UnderOwnerState<'tcx>>(
         s: &S,
         oid: rustc_hir::hir_id::OwnerId,
     ) -> ItemAttributes {


### PR DESCRIPTION
This PR is a bit unfortunate, it's packing a huge number of interleaved features...
However, each the (basic) CI is green on each and every commit, and I extensively cleaned up the history, so things should not be too much messed up. 

Previous description:
> This PR tweaks Hax so that it is able to translate [Rust's `core` library](https://github.com/rust-lang/rust/tree/master/library/core).
> 
> This PR adds a special mode for the exporter when exporting core. The environment variable `HAX_CORE_EXTRACTION_MODE`  disables attributes and makes every function body be unit (for now. This should be `panic` or something).
> 
> On about 20 000 definitions, for now, we're able to extract 19 000 definitions (without body). That takes about one minute. Things that fail to extract trigger the following errors:
> ```
> error[HAX0000]: (AST import) Unsafe blocks are not allowed.
> occurences: 213
> error[HAX0001]: (AndMutDefSite) something is not implemented yet.
> occurences: 13
> error[HAX0001]: (AST import) something is not implemented yet.
> occurences: 111
> error[HAX0001]: (FStar backend) something is not implemented yet.
> occurences: 294
> error[HAX0002]: (AndMutDefSite) Fatal error: something we considered as impossible occurred! Please report this by submitting an issue on GitHub!
> occurences: 5
> error[HAX0003]: (RefMut) The mutation of this &mut is not allowed here.
> occurences: 270
> error[HAX0008]: (reject_RawOrMutPointer) ExplicitRejection { reason: "unknown reason" }
> occurences: 1
> ```
> 
> I've tweaked and fixed some bugs in the F* backend, now I'm at a point where F* complains because of module cycles. That means we're producing syntaxically correct code for the whole core crate!
> 
> My plan is thus to implement https://github.com/hacspec/hacspec-v2/issues/203.
> 
> I push the current F* extraction there: https://github.com/W95Psp/rust/tree/hax/library/core/proofs/fstar/extraction