### PR TITLE
Engine: get rid of warning, and make most of them fatal

### DIFF
--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -9,13 +9,13 @@ on:
     
 jobs:
   docker:
-    if: ${{ github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'workflow_dispatch'  || github.event_name == 'merge_group'  }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - run: docker build -f .docker/Dockerfile . -t hacspec-v2
   setup_sh:
-    if: ${{ github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'workflow_dispatch'  || github.event_name == 'merge_group'   }}
     strategy:
       matrix:
         os:
@@ -47,7 +47,7 @@ jobs:
   setup_sh_status:
     if: |
       always() &&
-      github.event_name == 'merge_group'
+      github.event_name ==  'workflow_dispatch'  ||github.event_name ==  'merge_group'  
     needs: setup_sh
     runs-on: ubuntu-latest
     steps:

--- a/cli/default.nix
+++ b/cli/default.nix
@@ -1,64 +1,82 @@
-{craneLib, stdenv, makeWrapper, lib, rustc, gcc, hax-engine, doCheck ? true }:
-let
+{
+  craneLib,
+  stdenv,
+  makeWrapper,
+  lib,
+  rustc,
+  gcc,
+  hax-engine,
+  doCheck ? true,
+}: let
   pname = "hax";
   is-webapp-static-asset = path: builtins.match ".*(script[.]js|index[.]html)" path != null;
-  commonArgs = {
-    version = "0.0.1";
-    src = lib.cleanSourceWith {
-      src = craneLib.path ./..;
-      filter = path: type: builtins.isNull (builtins.match ".*/tests/.*" path) &&
-                           (craneLib.filterCargoSources path type || is-webapp-static-asset path);
-    };
-    inherit doCheck;
-  } // (if doCheck then {
-    # [cargo test] builds independent workspaces. Each time another
-    # workspace is added, it's corresponding lockfile should be added
-    # in the [cargoLockList] list below.
-    cargoVendorDir = craneLib.vendorMultipleCargoDeps {
-      cargoLockList = [
-        ../Cargo.lock
-        ../tests/Cargo.lock
-      ];
-    };
-  } else {});
-  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
-    pname = pname;
-  });
-  hax = craneLib.buildPackage (commonArgs // {
-    inherit cargoArtifacts pname;
-  });
-  binaries = [ hax hax-engine rustc gcc ];
-  tests = craneLib.buildPackage (commonArgs // {
-    inherit cargoArtifacts;
-    pname = "hax-tests";
-    doCheck = true;
-    CI = "true";
-    cargoBuildCommand = "true";
-    cargoTestCommand = ''
-      SNAPS_DIR=test-harness/src/snapshots && rmdir "$SNAPS_DIR"
-      TESTS_DIR=tests                      && rmdir "$TESTS_DIR"
+  commonArgs =
+    {
+      version = "0.0.1";
+      src = lib.cleanSourceWith {
+        src = craneLib.path ./..;
+        filter = path: type:
+          builtins.isNull (builtins.match ".*/tests/.*" path)
+          && (craneLib.filterCargoSources path type || is-webapp-static-asset path);
+      };
+      inherit doCheck;
+    }
+    // (
+      if doCheck
+      then {
+        # [cargo test] builds independent workspaces. Each time another
+        # workspace is added, it's corresponding lockfile should be added
+        # in the [cargoLockList] list below.
+        cargoVendorDir = craneLib.vendorMultipleCargoDeps {
+          cargoLockList = [
+            ../Cargo.lock
+            ../tests/Cargo.lock
+          ];
+        };
+      }
+      else {}
+    );
+  cargoArtifacts = craneLib.buildDepsOnly (commonArgs
+    // {
+      pname = pname;
+    });
+  hax = craneLib.buildPackage (commonArgs
+    // {
+      inherit cargoArtifacts pname;
+    });
+  binaries = [hax hax-engine rustc gcc];
+  tests = craneLib.buildPackage (commonArgs
+    // {
+      inherit cargoArtifacts;
+      pname = "hax-tests";
+      doCheck = true;
+      CI = "true";
+      cargoBuildCommand = "true";
+      checkPhaseCargoCommand = ''
+        SNAPS_DIR=test-harness/src/snapshots && rmdir "$SNAPS_DIR"
+        TESTS_DIR=tests                      && rmdir "$TESTS_DIR"
 
-      ln -s ${../test-harness/src/snapshots}        "$SNAPS_DIR"
-      cp -r --no-preserve=mode   ${../tests}        "$TESTS_DIR"
+        ln -s ${../test-harness/src/snapshots}        "$SNAPS_DIR"
+        cp -r --no-preserve=mode   ${../tests}        "$TESTS_DIR"
 
-      cargo test --test toolchain --profile release
-    '';
-    buildInputs = binaries;
-    CARGO_TESTS_ASSUME_BUILT = "yes";
-  });
+        cargo test --test toolchain --profile release
+      '';
+      buildInputs = binaries;
+      CARGO_TESTS_ASSUME_BUILT = "yes";
+    });
 in
-stdenv.mkDerivation {
-  name = hax.name;
-  buildInputs = [ makeWrapper ];
-  phases = ["installPhase"];
-  installPhase = ''
+  stdenv.mkDerivation {
+    name = hax.name;
+    buildInputs = [makeWrapper];
+    phases = ["installPhase"];
+    installPhase = ''
       mkdir -p $out/bin
       makeWrapper ${hax}/bin/cargo-hax $out/bin/cargo-hax \
         --prefix PATH : ${lib.makeBinPath binaries}
     '';
-  meta.mainProgram = "cargo-hax";
-  passthru = {
-    unwrapped = hax;
-    inherit tests;
-  };
-}
+    meta.mainProgram = "cargo-hax";
+    passthru = {
+      unwrapped = hax;
+      inherit tests;
+    };
+  }

--- a/engine/default.nix
+++ b/engine/default.nix
@@ -1,54 +1,84 @@
-{ocamlPackages, fetchzip, hax-rust-frontend, rustc, nodejs, jq, closurecompiler, gnused, lib}:
-let
-  non_empty_list = 
-    ocamlPackages.buildDunePackage rec {
-      pname = "non_empty_list";
-      version = "0.1";
-      src = fetchzip {
-        url = "https://github.com/johnyob/ocaml-non-empty-list/archive/refs/tags/${version}.zip";
-        sha256 = "sha256-BJlEi0yG2DRT5vuU9ulucMD5MPFt9duWgcNO1YsigiA=";
-      };
-      buildInputs = with ocamlPackages; [ base ppxlib ppx_deriving ];
-      duneVersion = "3";
-      minimalOCamlVersion = "4.08";
-      doCheck = false;
+{
+  ocamlPackages,
+  fetchzip,
+  hax-rust-frontend,
+  rustc,
+  nodejs,
+  jq,
+  closurecompiler,
+  gnused,
+  lib,
+}: let
+  non_empty_list = ocamlPackages.buildDunePackage rec {
+    pname = "non_empty_list";
+    version = "0.1";
+    src = fetchzip {
+      url = "https://github.com/johnyob/ocaml-non-empty-list/archive/refs/tags/${version}.zip";
+      sha256 = "sha256-BJlEi0yG2DRT5vuU9ulucMD5MPFt9duWgcNO1YsigiA=";
     };
-  ppx_matches = 
-    ocamlPackages.buildDunePackage rec {
-      pname = "ppx_matches";
-      version = "0.1";
+    buildInputs = with ocamlPackages; [base ppxlib ppx_deriving];
+    duneVersion = "3";
+    minimalOCamlVersion = "4.08";
+    doCheck = false;
+  };
+  ppx_matches = ocamlPackages.buildDunePackage rec {
+    pname = "ppx_matches";
+    version = "0.1";
 
-      src = fetchzip {
-        url = "https://github.com/wrbs/ppx_matches/archive/refs/tags/${version}.zip";
-        sha256 = "sha256-nAmWF8MgW0odKkRiFcHGsvJyIxNHaZpnOlNPsef89Fo=";
-      };
-
-      buildInputs = [
-        ocamlPackages.ppxlib
-      ];
-      duneVersion = "3";
-      minimalOCamlVersion = "4.04";
-      doCheck = false;
+    src = fetchzip {
+      url = "https://github.com/wrbs/ppx_matches/archive/refs/tags/${version}.zip";
+      sha256 = "sha256-nAmWF8MgW0odKkRiFcHGsvJyIxNHaZpnOlNPsef89Fo=";
     };
+
+    buildInputs = [
+      ocamlPackages.ppxlib
+    ];
+    duneVersion = "3";
+    minimalOCamlVersion = "4.04";
+    doCheck = false;
+  };
   hax-engine = ocamlPackages.buildDunePackage {
     pname = "hax-engine";
     version = "0.0.1";
     duneVersion = "3";
-    src = lib.sourceFilesBySuffices ./. [ ".ml" ".mli" ".js" "dune" "dune-project" "sh" "rs" ];
-    buildInputs = with ocamlPackages; [
-      zarith_stubs_js
-      base
-      ppx_yojson_conv yojson ppx_sexp_conv ppx_hash
-      visitors pprint non_empty_list bignum
-      ppx_deriving_yojson ppx_matches ppx_let cmdliner
-      angstrom ppx_string logs
-      core re
-    ] ++
-    # F* dependencies
-    [ batteries menhirLib ppx_deriving
-      ppxlib sedlex stdint zarith ];
+    src = lib.sourceFilesBySuffices ./. [".ml" ".mli" ".js" "dune" "dune-project" "sh" "rs"];
+    buildInputs = with ocamlPackages;
+      [
+        zarith_stubs_js
+        base
+        ppx_yojson_conv
+        yojson
+        ppx_sexp_conv
+        ppx_hash
+        visitors
+        pprint
+        non_empty_list
+        bignum
+        ppx_deriving_yojson
+        ppx_matches
+        ppx_let
+        cmdliner
+        angstrom
+        ppx_string
+        logs
+        core
+        re
+      ]
+      ++
+      # F* dependencies
+      [
+        batteries
+        menhirLib
+        ppx_deriving
+        ppxlib
+        sedlex
+        stdint
+        zarith
+      ];
     nativeBuildInputs = [
-      rustc hax-rust-frontend nodejs
+      rustc
+      hax-rust-frontend
+      nodejs
       ocamlPackages.js_of_ocaml-compiler
       jq
     ];
@@ -72,4 +102,4 @@ let
     };
   };
 in
-hax-engine
+  hax-engine

--- a/engine/dune-project
+++ b/engine/dune-project
@@ -22,7 +22,7 @@
  (depends
         ocaml
         dune
-        base
+        (base (>= "0.16.2"))
         core
         yojson
         non_empty_list

--- a/engine/hax-engine.opam
+++ b/engine/hax-engine.opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/username/reponame/issues"
 depends: [
   "ocaml"
   "dune" {>= "3.0"}
-  "base"
+  "base" {>= "0.16.2"}
   "core"
   "yojson"
   "non_empty_list"

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -1,6 +1,4 @@
-open Base
-open Utils
-open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+open! Prelude
 
 type todo = string
 [@@deriving

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -78,8 +78,8 @@ module Make (F : Features.T) = struct
       let show (x : t) : string =
         [%show: TypedLocalIdent.t list] @@ Set.to_list x
 
-      let pp (fmt : Caml.Format.formatter) (s : t) : unit =
-        Caml.Format.pp_print_string fmt @@ show s
+      let pp (fmt : Stdlib.Format.formatter) (s : t) : unit =
+        Stdlib.Format.pp_print_string fmt @@ show s
 
       class ['s] monoid =
         object
@@ -347,7 +347,7 @@ module Make (F : Features.T) = struct
       |> List.filter_map ~f:(fun ({ name; _ } : local_ident) ->
              String.chop_prefix ~prefix name)
       |> List.map ~f:(function "" -> "0" | s -> s)
-      |> List.filter_map ~f:Caml.int_of_string_opt
+      |> List.filter_map ~f:Stdlib.int_of_string_opt
       |> List.fold ~init:(-1) ~f:Int.max
       |> ( + ) 1
       |> function
@@ -562,8 +562,8 @@ module Make (F : Features.T) = struct
     TApp { ident; args = [] }
 
   module LiftToFullAst = struct
-    let expr : AST.expr -> Ast.Full.expr = Caml.Obj.magic
-    let item : AST.expr -> Ast.Full.expr = Caml.Obj.magic
+    let expr : AST.expr -> Ast.Full.expr = Stdlib.Obj.magic
+    let item : AST.expr -> Ast.Full.expr = Stdlib.Obj.magic
   end
 
   let unbox_expr' (next : expr -> expr) (e : expr) : expr =

--- a/engine/lib/backend.ml
+++ b/engine/lib/backend.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 open Ast
 
 module type BACKEND_OPTIONS = sig

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -1,6 +1,4 @@
-open Base
-open Utils
-open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+open! Prelude
 
 module Imported = struct
   type def_id = { krate : string; path : disambiguated_def_path_item list }
@@ -51,12 +49,12 @@ module Imported = struct
       disambiguator = MyInt64.to_int_exn disambiguator;
     }
 
-  let of_def_id Types.{ krate; path } =
+  let of_def_id Types.{ krate; path; _ } =
     { krate; path = List.map ~f:of_disambiguated_def_path_item path }
 
-  let parent { krate; path } = { krate; path = List.drop_last_exn path }
+  let parent { krate; path; _ } = { krate; path = List.drop_last_exn path }
 
-  let drop_ctor { krate; path } =
+  let drop_ctor { krate; path; _ } =
     {
       krate;
       path =
@@ -192,8 +190,8 @@ module MakeViewAPI (NP : NAME_POLICY) : VIEW_API = struct
   let pp fmt = show >> Caml.Format.pp_print_string fmt
   let is_reserved_word : string -> bool = Hash_set.mem NP.reserved_words
 
-  let rename_definition (path : string list) (name : string) (kind : Kind.t)
-      type_name =
+  let rename_definition (_path : string list) (name : string) (kind : Kind.t)
+      _type_name =
     (* let path, name = *)
     (*   match kind with *)
     (*   | Constructor { is_struct = false } -> *)

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -118,7 +118,7 @@ module View = struct
              | 0 -> (
                  match String.rsplit2 ~on:'_' base with
                  | Some (_, "") -> base ^ "_"
-                 | Some (_, r) when Option.is_some @@ Caml.int_of_string_opt r
+                 | Some (_, r) when Option.is_some @@ Stdlib.int_of_string_opt r
                    ->
                      base ^ "_" (* potentially conflicting name, adding a `_` *)
                  | _ -> base)
@@ -187,7 +187,7 @@ end)
 module MakeViewAPI (NP : NAME_POLICY) : VIEW_API = struct
   type t = T.t
 
-  let pp fmt = show >> Caml.Format.pp_print_string fmt
+  let pp fmt = show >> Stdlib.Format.pp_print_string fmt
   let is_reserved_word : string -> bool = Hash_set.mem NP.reserved_words
 
   let rename_definition (_path : string list) (name : string) (kind : Kind.t)
@@ -216,7 +216,7 @@ module MakeViewAPI (NP : NAME_POLICY) : VIEW_API = struct
         if start_lowercase name || is_reserved_word name then "C_" ^ name
         else escape name
     | Field -> (
-        match Caml.int_of_string_opt name with
+        match Stdlib.int_of_string_opt name with
         | Some _ -> NP.index_field_transform name
         (* | _ -> "f_" ^ Option.value_exn type_name ^ "_" ^ name *)
         | _ -> "f_" ^ name)

--- a/engine/lib/concrete_ident/concrete_ident_sig.ml
+++ b/engine/lib/concrete_ident/concrete_ident_sig.ml
@@ -1,4 +1,4 @@
-open Base
+open! Prelude
 
 module Make (T : sig
   type t_
@@ -18,7 +18,7 @@ struct
 
   module type VIEW_API = sig
     val show : t_ -> string
-    val pp : Format.formatter -> t_ -> unit
+    val pp : Formatter.t -> t_ -> unit
     val to_view : t_ -> view_
     val to_definition_name : t_ -> string
     val to_crate_name : t_ -> string

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -76,7 +76,8 @@ let to_thir_diagnostic (d : t) : Types.diagnostics_for__array_of__span =
 let run_hax_pretty_print_diagnostics (s : string) : string =
   try (Utils.Command.run "hax-pretty-print-diagnostics" s).stdout
   with e ->
-    "[run_hax_pretty_print_diagnostics] failed. Exn: " ^ Printexc.to_string e
+    "[run_hax_pretty_print_diagnostics] failed. Exn: "
+    ^ "[run_hax_pretty_print_diagnostics] failed. Exn: " ^ Exn.to_string e
     ^ ". Here is the JSON representation of the error that occurred:\n" ^ s
 
 let pretty_print : t -> string =

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -1,4 +1,4 @@
-open Utils
+open! Prelude
 module T = Types
 
 module Backend = struct

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -1,5 +1,4 @@
 open Utils
-open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 module T = Types
 
 module Backend = struct

--- a/engine/lib/dune
+++ b/engine/lib/dune
@@ -33,6 +33,17 @@
 (include_subdirs unqualified)
 
 (rule
+  (alias universe-hash)
+  (target universe-hash)
+  (deps (:universe_hash ../utils/universe-hash.sh)
+        (universe)
+  )
+  (action
+    (with-stdout-to universe-hash
+      (run bash %{universe_hash})))
+)
+
+(rule
  (target concrete_ident_generated.ml)
  (deps
   (:generate_sh concrete_ident/generate.sh)
@@ -45,6 +56,7 @@
 (rule
  (target types.ml)
  (deps
+  (alias universe-hash)
   (env_var HAX_JSON_SCHEMA_EXPORTER_BINARY)
   (:ocaml_of_json_schema
    ../utils/ocaml_of_json_schema/ocaml_of_json_schema.js))

--- a/engine/lib/dune
+++ b/engine/lib/dune
@@ -58,4 +58,4 @@
 (env
  (_
   (flags
-   (:standard -g -warn-error "-A+8" -w "-17-7-30-56-32"))))
+   (:standard -g -warn-error "+A" -w "-17-7-30-56-32"))))

--- a/engine/lib/feature_gate.ml
+++ b/engine/lib/feature_gate.ml
@@ -1,6 +1,4 @@
-open Base
-open Ppx_yojson_conv_lib.Yojson_conv.Primitives
-open Utils
+open! Prelude
 
 module DefaultSubtype = struct
   type error = Err [@@deriving show, yojson, eq]
@@ -31,8 +29,6 @@ module Make
     with module A = FA
      and module B = FB) =
 struct
-  open Ast
-
   let metadata = S0.metadata
 
   module S =
@@ -43,7 +39,6 @@ struct
             (x : a) : b =
           try f x
           with S0.E err ->
-            let message = S0.explain err feature_kind in
             let kind : Diagnostics.kind =
               ExplicitRejection { reason = S0.explain err feature_kind }
             in

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -13,8 +13,7 @@ module Thir = struct
   type trait_item = trait_item_for__decorated_for__expr_kind
 end
 
-open Utils
-open Base
+open! Prelude
 open Diagnostics
 
 let assertion_failure (span : Thir.span list) (details : string) =
@@ -386,7 +385,8 @@ module Make (Opts : OPTS) : MakeT = struct
             let args = List.map ~f:c_expr args in
             let f = c_expr fun' in
             App { f; args }
-        | Box { value } -> (U.call Rust_primitives__hax__box_new [] span typ).e
+        | Box { value } ->
+            (U.call Rust_primitives__hax__box_new [ c_expr value ] span typ).e
         | Deref { arg } ->
             let inner_typ = c_ty arg.span arg.ty in
             call (mk_global ([ inner_typ ] ->. typ) @@ `Primitive Deref) [ arg ]
@@ -853,7 +853,7 @@ module Make (Opts : OPTS) : MakeT = struct
       | Uint k -> TInt (c_uint_ty k)
       | Float k -> TFloat (match k with F32 -> F32 | F64 -> F64)
       | Arrow value ->
-          let ({ inputs; output } : Thir.ty_fn_sig) = value.value in
+          let ({ inputs; output; _ } : Thir.ty_fn_sig) = value.value in
           TArrow (List.map ~f:(c_ty span) inputs, c_ty span output)
       | Adt { def_id = id; generic_args } ->
           let ident = def_id Type id in

--- a/engine/lib/phase_utils.ml
+++ b/engine/lib/phase_utils.ml
@@ -104,8 +104,8 @@ module DebugPhaseInfo = struct
     | Before -> "initial_input"
     | Phase p -> Diagnostics.Phase.display p
 
-  let pp (fmt : Caml.Format.formatter) (s : t) : unit =
-    Caml.Format.pp_print_string fmt @@ show s
+  let pp (fmt : Stdlib.Format.formatter) (s : t) : unit =
+    Stdlib.Format.pp_print_string fmt @@ show s
 end
 
 module DebugBindPhase : sig
@@ -205,11 +205,11 @@ struct
   let ditems (items : A.item list) : B.item list =
     let nth = List.length @@ Metadata.previous_phases D1'.metadata in
     (if Int.equal nth 0 then
-     let coerce_to_full_ast : D1'.A.item -> Ast.Full.item = Caml.Obj.magic in
+     let coerce_to_full_ast : D1'.A.item -> Ast.Full.item = Stdlib.Obj.magic in
      DebugBindPhase.add Before 0 (fun _ -> List.map ~f:coerce_to_full_ast items));
     let items' = D1'.ditems items in
     let coerce_to_full_ast : D2'.A.item list -> Ast.Full.item list =
-      Caml.Obj.magic
+      Stdlib.Obj.magic
     in
     DebugBindPhase.add (Phase D1'.metadata.current_phase) (nth + 1) (fun _ ->
         coerce_to_full_ast items');

--- a/engine/lib/phase_utils.ml
+++ b/engine/lib/phase_utils.ml
@@ -1,6 +1,4 @@
-open Base
-open Utils
-open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+open! Prelude
 
 module Metadata : sig
   type t = private {

--- a/engine/lib/phases/phase_and_mut_defsite.ml
+++ b/engine/lib/phases/phase_and_mut_defsite.ml
@@ -225,7 +225,7 @@ struct
     include M
 
     let ditems (items : A.item list) : B.item list =
-      let items : B.item list = Caml.Obj.magic items in
+      let items : B.item list = Stdlib.Obj.magic items in
       let visitor =
         object
           inherit [_] B.item_map as super
@@ -291,7 +291,7 @@ struct
             try super#visit_item () i
             with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
               let error = Diagnostics.pretty_print_context_kind context kind in
-              let cast_item : B.item -> Ast.Full.item = Caml.Obj.magic in
+              let cast_item : B.item -> Ast.Full.item = Stdlib.Obj.magic in
               let ast = cast_item i |> Print_rust.pitem_str in
               let msg =
                 error ^ "\nLast available AST for this item:\n\n" ^ ast
@@ -310,7 +310,7 @@ struct
       List.map ~f:(visitor#visit_item ()) items
 
     let dexpr (_e : A.expr) : B.expr =
-      Caml.failwith "Should not be called directly"
+      Stdlib.failwith "Should not be called directly"
   end
 
   include Implem

--- a/engine/lib/phases/phase_and_mut_defsite.ml
+++ b/engine/lib/phases/phase_and_mut_defsite.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make
     (FA : Features.T
@@ -48,7 +47,6 @@ struct
 
       let expect_mut_ref_param (param : param) :
           (local_ident * ty * span) option =
-        let x = 0 in
         let* typ = Expect.mut_ref param.typ in
         match param.pat.p with
         | PBinding
@@ -89,7 +87,7 @@ struct
       let map_returns ~(f : expr -> expr) : expr -> expr =
         let visitor =
           object
-            inherit [_] expr_map as super
+            inherit [_] expr_map as _super
             method visit_t () x = x
             method visit_mutability _ () m = m
             method visit_Return () e witness = Return { e = f e; witness }
@@ -205,7 +203,7 @@ struct
 
       let rewrite_function (params : param list) (body : expr) :
           (param list * expr) option =
-        let* params, body_typ, vars = rewrite_fn_sig params body.typ in
+        let* params, _, vars = rewrite_fn_sig params body.typ in
         let idents = List.map ~f:fst3 vars in
         let vars =
           List.map
@@ -227,7 +225,7 @@ struct
     include M
 
     let ditems (items : A.item list) : B.item list =
-      let items : B.item list = Obj.magic items in
+      let items : B.item list = Caml.Obj.magic items in
       let visitor =
         object
           inherit [_] B.item_map as super
@@ -293,7 +291,7 @@ struct
             try super#visit_item () i
             with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
               let error = Diagnostics.pretty_print_context_kind context kind in
-              let cast_item : B.item -> Ast.Full.item = Obj.magic in
+              let cast_item : B.item -> Ast.Full.item = Caml.Obj.magic in
               let ast = cast_item i |> Print_rust.pitem_str in
               let msg =
                 error ^ "\nLast available AST for this item:\n\n" ^ ast
@@ -311,7 +309,7 @@ struct
       in
       List.map ~f:(visitor#visit_item ()) items
 
-    let dexpr (e : A.expr) : B.expr =
+    let dexpr (_e : A.expr) : B.expr =
       Caml.failwith "Should not be called directly"
   end
 

--- a/engine/lib/phases/phase_and_mut_defsite.mli
+++ b/engine/lib/phases/phase_and_mut_defsite.mli
@@ -1,5 +1,3 @@
-open Base
-open Utils
 
 module Make
     (F : Features.T

--- a/engine/lib/phases/phase_cf_into_monads.ml
+++ b/engine/lib/phases/phase_cf_into_monads.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make
     (F : Features.T
@@ -117,15 +116,14 @@ struct
             in
             Option.some
               (match (m1, m2) with
-              | (B.MResult _ | B.MOption _), (B.MException _ as m)
-              | (B.MException _ as m), (B.MResult _ | B.MOption _) ->
+              | (B.MResult _ | B.MOption), (B.MException _ as m)
+              | (B.MException _ as m), (B.MResult _ | B.MOption) ->
                   m
               | B.MResult _, B.MResult _
-              | B.MOption _, B.MOption _
+              | B.MOption, B.MOption
               | B.MException _, B.MException _ ->
                   m1
-              | B.MResult _, B.MOption _ | B.MOption _, B.MResult _ ->
-                  impossible ())
+              | B.MResult _, B.MOption | B.MOption, B.MResult _ -> impossible ())
 
       (** after transformation, are we **getting** inside a monad? *)
       let from_typ dty (old : A.ty) (new_ : B.ty) : t =

--- a/engine/lib/phases/phase_cf_into_monads.mli
+++ b/engine/lib/phases/phase_cf_into_monads.mli
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module Make
     (F : Features.T

--- a/engine/lib/phases/phase_direct_and_mut.ml
+++ b/engine/lib/phases/phase_direct_and_mut.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make
     (FA : Features.T
@@ -210,7 +209,7 @@ struct
           in
           (* when lhs type accepts tuple (issue #222), assigns will be an option instead of a list *)
           let assigns =
-            let flatten (o, meta) = Option.map o Fn.(id &&& const meta) in
+            let flatten (o, meta) = Option.map o ~f:Fn.(id &&& const meta) in
             List.filter_map ~f:flatten mutargs
             |> List.map ~f:(fun ((var, lhs), (typ, span)) ->
                    let e = B.{ e = LocalVar var; span; typ } in

--- a/engine/lib/phases/phase_direct_and_mut.mli
+++ b/engine/lib/phases/phase_direct_and_mut.mli
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module Make
     (F : Features.T

--- a/engine/lib/phases/phase_drop_blocks.ml
+++ b/engine/lib/phases/phase_drop_blocks.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make (F : Features.T) = struct
   open Ast

--- a/engine/lib/phases/phase_drop_blocks.mli
+++ b/engine/lib/phases/phase_drop_blocks.mli
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module Make (F : Features.T) : sig
   include module type of struct

--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make
     (F : Features.T
@@ -65,7 +64,6 @@ struct
     and dexpr' (span : span) (e : A.expr') : B.expr' =
       match (UA.unbox_underef_expr { e; span; typ = UA.never_typ }).e with
       | [%inline_arms If + Literal + Array + App + Block] -> auto
-      | App { f; args } -> App { f = dexpr f; args = List.map ~f:dexpr args }
       | Construct { constructor; is_record; is_struct; fields; base } ->
           Construct
             {
@@ -116,7 +114,7 @@ struct
         bindings = r.bindings;
       }
 
-    let dgeneric_param (span : span)
+    let dgeneric_param (_span : span)
         ({ ident; kind; attrs; span } : A.generic_param) :
         B.generic_param option =
       let ( let* ) x f = Option.bind ~f x in

--- a/engine/lib/phases/phase_drop_references.mli
+++ b/engine/lib/phases/phase_drop_references.mli
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module Make
     (F : Features.T

--- a/engine/lib/phases/phase_functionalize_loops.ml
+++ b/engine/lib/phases/phase_functionalize_loops.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make
     (F : Features.T

--- a/engine/lib/phases/phase_functionalize_loops.mli
+++ b/engine/lib/phases/phase_functionalize_loops.mli
@@ -1,12 +1,10 @@
-open Base
-open Utils
+open! Prelude
 
 module Make
     (F : Features.T
            with type continue = Features.Off.continue
             and type early_exit = Features.Off.early_exit) : sig
   include module type of struct
-    open Ast
     module FA = F
 
     module FB = struct

--- a/engine/lib/phases/phase_local_mutation.ml
+++ b/engine/lib/phases/phase_local_mutation.ml
@@ -1,6 +1,5 @@
 (* TODO: handle Exn report *)
-open Base
-open Utils
+open! Prelude
 open Side_effect_utils
 
 module%inlined_contents Make

--- a/engine/lib/phases/phase_local_mutation.mli
+++ b/engine/lib/phases/phase_local_mutation.mli
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module Make
     (F : Features.T
@@ -12,7 +11,6 @@ module Make
             and type monadic_binding = Features.Off.monadic_binding
             and type for_index_loop = Features.Off.for_index_loop) : sig
   include module type of struct
-    open Ast
     module FA = F
 
     module FB = struct

--- a/engine/lib/phases/phase_reconstruct_for_loops.ml
+++ b/engine/lib/phases/phase_reconstruct_for_loops.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make
     (FA : Features.T

--- a/engine/lib/phases/phase_reconstruct_for_loops.mli
+++ b/engine/lib/phases/phase_reconstruct_for_loops.mli
@@ -1,9 +1,7 @@
-open Base
-open Utils
+open! Prelude
 
 module Make (F : Features.T) : sig
   include module type of struct
-    open Ast
     module FA = F
 
     module FB = struct

--- a/engine/lib/phases/phase_reconstruct_question_marks.ml
+++ b/engine/lib/phases/phase_reconstruct_question_marks.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make (FA : Features.T) = struct
   open Ast

--- a/engine/lib/phases/phase_reconstruct_question_marks.mli
+++ b/engine/lib/phases/phase_reconstruct_question_marks.mli
@@ -1,9 +1,7 @@
-open Base
-open Utils
+open! Prelude
 
 module Make (F : Features.T) : sig
   include module type of struct
-    open Ast
     module FA = F
 
     module FB = struct

--- a/engine/lib/phases/phase_recontruct_for_index_loops.ml
+++ b/engine/lib/phases/phase_recontruct_for_index_loops.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make (FA : Features.T) = struct
   open Ast
@@ -38,7 +37,7 @@ module%inlined_contents Make (FA : Features.T) = struct
                 e =
                   App
                     {
-                      f = { e = GlobalVar (`Concrete into_iter_meth) };
+                      f = { e = GlobalVar (`Concrete into_iter_meth); _ };
                       args =
                         [
                           {
@@ -55,6 +54,7 @@ module%inlined_contents Make (FA : Features.T) = struct
                                     ];
                                   base = None;
                                 };
+                            _;
                           };
                         ];
                     };
@@ -65,10 +65,10 @@ module%inlined_contents Make (FA : Features.T) = struct
               {
                 p =
                   PBinding
-                    { mut = Immutable; mode = ByValue; var; subpat = None };
-                typ = _;
+                    { mut = Immutable; mode = ByValue; var; subpat = None; _ };
+                _;
               };
-            witness;
+            _;
           }
         when Concrete_ident.eq_name
                Core__iter__traits__collect__IntoIterator__into_iter

--- a/engine/lib/phases/phase_trivialize_assign_lhs.ml
+++ b/engine/lib/phases/phase_trivialize_assign_lhs.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module%inlined_contents Make (F : Features.T) = struct
   open Ast
@@ -62,7 +61,7 @@ module%inlined_contents Make (F : Features.T) = struct
         (LocalIdent.t * B.ty) * B.expr =
       match lhs with
       | LhsLocalVar { var; typ } -> ((var, dty span typ), rhs)
-      | LhsFieldAccessor { e; typ; field; _ } -> (
+      | LhsFieldAccessor { e; field; _ } -> (
           let lhs = expr_of_lhs e span in
           let field =
             match field with
@@ -70,7 +69,7 @@ module%inlined_contents Make (F : Features.T) = struct
             | _ -> field
           in
           match lhs.typ with
-          | TApp { ident; args } ->
+          | TApp { ident; _ } ->
               let rhs' =
                 B.Construct
                   {

--- a/engine/lib/phases/phase_trivialize_assign_lhs.mli
+++ b/engine/lib/phases/phase_trivialize_assign_lhs.mli
@@ -1,9 +1,5 @@
-open Base
-open Utils
-
 module Make (F : Features.T) : sig
   include module type of struct
-    open Ast
     module FA = F
 
     module FB = struct

--- a/engine/lib/prelude.ml
+++ b/engine/lib/prelude.ml
@@ -1,0 +1,3 @@
+include Base
+include Utils
+include Ppx_yojson_conv_lib.Yojson_conv.Primitives

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -523,7 +523,7 @@ let pexpr_str (e : expr) : string =
   let suffix = "}" in
   let item = !prefix & e & !suffix in
   rustfmt_annotated item |> AnnotatedString.Output.convert
-  |> AnnotatedString.Output.raw_string |> Caml.String.trim
+  |> AnnotatedString.Output.raw_string |> Stdlib.String.trim
   |> String.chop_suffix_if_exists ~suffix
   |> String.chop_prefix_if_exists ~prefix
-  |> Caml.String.trim
+  |> Stdlib.String.trim

--- a/engine/lib/side_effect_utils.ml
+++ b/engine/lib/side_effect_utils.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module MakeSI
     (F : Features.T
@@ -355,7 +354,8 @@ struct
                   ({ e with e = App { f; args } }, effects))
           | Literal _ -> (e, m#zero)
           | Block (inner, witness) ->
-              HoistSeq.one env (super#visit_expr env e) (fun inner effects ->
+              HoistSeq.one env (super#visit_expr env inner)
+                (fun inner effects ->
                   ({ e with e = Block (inner, witness) }, effects))
           | Array l ->
               HoistSeq.many env

--- a/engine/lib/side_effect_utils.ml
+++ b/engine/lib/side_effect_utils.ml
@@ -205,7 +205,7 @@ struct
           (next : expr -> t -> expr * t) =
         many ctx [ e ] (function
           | [ e ] -> next e
-          | _ -> err_hoist_invariant (fst e).span Caml.__LOC__)
+          | _ -> err_hoist_invariant (fst e).span Stdlib.__LOC__)
     end
 
     let let_of_binding ((pat, rhs) : pat * expr) (body : expr) : expr =
@@ -305,14 +305,14 @@ struct
                         ForLoop { pat; witness; it }
                     | ([ _ ] | []), UnconditionalLoop -> UnconditionalLoop
                     | _, ForIndexLoop _ -> .
-                    | _ -> HoistSeq.err_hoist_invariant e.span Caml.__LOC__
+                    | _ -> HoistSeq.err_hoist_invariant e.span Stdlib.__LOC__
                   in
                   let state =
                     match (l, state) with
                     | (_ :: [ state ] | [ state ]), Some { witness; bpat; _ } ->
                         Some { witness; bpat; init = state }
                     | ([ _ ] | []), None -> None
-                    | _ -> HoistSeq.err_hoist_invariant e.span Caml.__LOC__
+                    | _ -> HoistSeq.err_hoist_invariant e.span Stdlib.__LOC__
                   in
                   (* by now, the "inputs" of the loop are hoisted as let if needed *)
                   let body, { lbs; effects = body_effects } =
@@ -349,7 +349,7 @@ struct
                   let f, args =
                     match l with
                     | f :: args -> (f, args)
-                    | _ -> HoistSeq.err_hoist_invariant e.span Caml.__LOC__
+                    | _ -> HoistSeq.err_hoist_invariant e.span Stdlib.__LOC__
                   in
                   ({ e with e = App { f; args } }, effects))
           | Literal _ -> (e, m#zero)
@@ -386,13 +386,13 @@ struct
                     match (l, base) with
                     | hd :: tl, Some (_, witness) -> (Some (hd, witness), tl)
                     | _, None -> (None, l)
-                    | _ -> HoistSeq.err_hoist_invariant e.span Caml.__LOC__
+                    | _ -> HoistSeq.err_hoist_invariant e.span Stdlib.__LOC__
                   in
                   let fields =
                     match List.zip (List.map ~f:fst fields) fields_expr with
                     | Ok fields -> fields
                     | Unequal_lengths ->
-                        HoistSeq.err_hoist_invariant e.span Caml.__LOC__
+                        HoistSeq.err_hoist_invariant e.span Stdlib.__LOC__
                   in
                   ( {
                       e with

--- a/engine/lib/span.ml
+++ b/engine/lib/span.ml
@@ -1,6 +1,4 @@
-open Base
-open Utils
-open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+open! Prelude
 
 module FreshId = struct
   let current = ref 1
@@ -101,7 +99,7 @@ end
 type t = { id : int; data : Imported.span list }
 [@@deriving show, yojson, sexp, compare, eq, hash]
 
-let display { id; data } =
+let display { id = _; data } =
   match data with
   | [] -> "<dummy>"
   | [ span ] -> Imported.display_span span

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -350,7 +350,7 @@ struct
       try ditem_unwrapped i
       with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
         let error = Diagnostics.pretty_print_context_kind context kind in
-        let cast_item : A.item -> Ast.Full.item = Caml.Obj.magic in
+        let cast_item : A.item -> Ast.Full.item = Stdlib.Obj.magic in
         let ast = cast_item i |> Print_rust.pitem_str in
         let msg = error ^ "\nLast available AST for this item:\n\n" ^ ast in
         [ B.make_hax_error_item i.span i.ident msg ]

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -1,5 +1,4 @@
-open Base
-open Utils
+open! Prelude
 
 module Make
     (FA : Features.T)
@@ -111,7 +110,7 @@ struct
     with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
       let typ : B.ty =
         try dty e.span e.typ
-        with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
+        with Diagnostics.SpanFreeError.Exn (Data (_context, _kind)) ->
           UB.hax_failure_typ
       in
       UB.hax_failure_expr e.span typ (context, kind) (UA.LiftToFullAst.expr e)
@@ -276,7 +275,7 @@ struct
       }
 
     (* TODO: remvove span argument *)
-    let dgeneric_param (span : span)
+    let dgeneric_param (_span : span)
         ({ ident; span; attrs; kind } : A.generic_param) : B.generic_param =
       let kind =
         match kind with
@@ -351,7 +350,7 @@ struct
       try ditem_unwrapped i
       with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
         let error = Diagnostics.pretty_print_context_kind context kind in
-        let cast_item : A.item -> Ast.Full.item = Obj.magic in
+        let cast_item : A.item -> Ast.Full.item = Caml.Obj.magic in
         let ast = cast_item i |> Print_rust.pitem_str in
         let msg = error ^ "\nLast available AST for this item:\n\n" ^ ast in
         [ B.make_hax_error_item i.span i.ident msg ]

--- a/engine/lib/utils.ml
+++ b/engine/lib/utils.ml
@@ -80,7 +80,7 @@ module Command = struct
       flush stdin;
       close stdin);
     let strout = In_channel.input_all stdout in
-    let strerr = In_channel.input_all stderr |> Caml.String.trim in
+    let strerr = In_channel.input_all stderr |> Stdlib.String.trim in
     Unix.close @@ Unix.descr_of_in_channel stdout;
     Unix.close @@ Unix.descr_of_in_channel stderr;
     { stdout = strout; stderr = strerr }

--- a/engine/lib/utils.ml
+++ b/engine/lib/utils.ml
@@ -95,5 +95,5 @@ module MyInt64 = struct
     | `Int i -> of_int i
     | _ -> failwith "Couldn't parse MyInt64.t"
 
-  let yojson_of_t (x : t) : Yojson.Safe.t = failwith "x"
+  let yojson_of_t (int64 : t) : Yojson.Safe.t = `Intlit (to_string int64)
 end

--- a/engine/utils/hacspeclib-macro-parser/hacspeclib_macro_parser.ml
+++ b/engine/utils/hacspeclib-macro-parser/hacspeclib_macro_parser.ml
@@ -59,8 +59,8 @@ end = struct
     match parse_string ~consume:All (parens parser <* end_of_input) input with
     | Ok e -> Ok e
     | Error e ->
-        Caml.prerr_endline @@ "########## Error while parsing: (" ^ name ^ ")";
-        Caml.prerr_endline input;
+        Stdlib.prerr_endline @@ "########## Error while parsing: (" ^ name ^ ")";
+        Stdlib.prerr_endline input;
         Error e
 end
 

--- a/engine/utils/ppx_functor_application/ppx_functor_application.ml
+++ b/engine/utils/ppx_functor_application/ppx_functor_application.ml
@@ -1,6 +1,6 @@
 open Base
 open Ppxlib
-module Format = Caml.Format
+module Format = Stdlib.Format
 
 let name = "functor_application"
 

--- a/engine/utils/ppx_inline/ppx_inline.ml
+++ b/engine/utils/ppx_inline/ppx_inline.ml
@@ -93,14 +93,14 @@ let replace_every_location (location : location) =
 
 let locate_module (name : string) : string =
   let rec find = function
-    | path when Caml.Sys.is_directory path ->
-        Caml.Sys.readdir path
+    | path when Stdlib.Sys.is_directory path ->
+        Stdlib.Sys.readdir path
         |> Array.find_map ~f:(fun name ->
-               find @@ Caml.Filename.concat path name)
-    | path when String.(Caml.Filename.basename path = name) -> Some path
+               find @@ Stdlib.Filename.concat path name)
+    | path when String.(Stdlib.Filename.basename path = name) -> Some path
     | _ -> None
   in
-  find (Caml.Sys.getcwd ())
+  find (Stdlib.Sys.getcwd ())
   |> Option.value_exn ~message:("ppx_inline: could not locate module " ^ name)
 
 let inlinable_items_of_module : loc:location -> string -> inlinable_item list =
@@ -110,7 +110,7 @@ let inlinable_items_of_module : loc:location -> string -> inlinable_item list =
       ~default:(fun () ->
         let results = ref [] in
         let _ =
-          locate_module path |> Caml.open_in |> Lexing.from_channel
+          locate_module path |> Stdlib.open_in |> Lexing.from_channel
           |> Parse.implementation |> (replace_every_location loc)#structure
           |> (collect_ast_nodes results)#structure [ path ]
         in

--- a/engine/utils/universe-hash.sh
+++ b/engine/utils/universe-hash.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# this script computes the hash of [hax-export-json-schemas], so that
+# whenver this binary change, dune retriggers a generation of
+# `types.ml` (see `../lib/dune`).
+
+function fallback() {
+    echo "${RANDOM}_$(date +%s)"
+}
+
+function hash() {
+    if command -v sha256sum &> /dev/null; then
+        sha256sum < "$1"
+    elif command -v md5sum &> /dev/null; then
+        md5sum < "$1"
+    elif command -v openssl &> /dev/null; then
+        openssl sha256 < "$1"
+    else
+        fallback
+    fi
+}
+
+HAX_JSON_SCHEMA_EXPORTER_BINARY=${HAX_JSON_SCHEMA_EXPORTER_BINARY:-hax-export-json-schemas}
+
+if BIN=$(command -v "$HAX_JSON_SCHEMA_EXPORTER_BINARY"); then
+    hash "$BIN"
+else
+    DIAG="looks like it's **NOT** the case!"
+    if [[ ":$PATH:" == *":$HOME/.cargo/bin"{,/}":"* ]]; then
+        DIAG="this seems to be the case"
+    fi
+    echo "Error: could not find [$HAX_JSON_SCHEMA_EXPORTER_BINARY] in PATH." >&2
+    echo "Please make sure that:" >&2
+    echo "  - you ran Hax's `setup.sh` script;" >&2
+    echo "  - you have `~/.cargo/bin` in your PATH ($DIAG)." >&2
+    exit 1
+fi
+

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1686621798,
-        "narHash": "sha256-FUwWszmSiDzUdTk8f69xwMoYlhdPaLvDaIYOE/y6VXc=",
+        "lastModified": 1693787605,
+        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "75f7d715f8088f741be9981405f6444e2d49efdd",
+        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686582075,
-        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
+        "lastModified": 1694343207,
+        "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
+        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685759304,
-        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
+        "lastModified": 1693707092,
+        "narHash": "sha256-HR1EnynBSPqbt+04/yxxqsG1E3n6uXrOl7SPco/UnYo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
+        "rev": "98ccb73e6eefc481da6039ee57ad8818d1ca8d56",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,15 @@
     rust-overlay.follows = "crane/rust-overlay";
   };
 
-  outputs = {flake-utils, nixpkgs, rust-overlay, crane, ...}:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
+  outputs = {
+    flake-utils,
+    nixpkgs,
+    rust-overlay,
+    crane,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
         pkgs = import nixpkgs {
           inherit system;
           overlays = [rust-overlay.overlays.default];
@@ -38,10 +44,13 @@
         };
         checks.default = packages.hax.tests;
         apps = {
-          serve-rustc-docs = { type = "app"; program = "${pkgs.writeScript "serve-rustc-docs" ''
-             cd ${packages.rustc.passthru.availableComponents.rustc-docs}/share/doc/rust/html/rustc
-             ${pkgs.python3}/bin/python -m http.server
-          ''}"; };
+          serve-rustc-docs = {
+            type = "app";
+            program = "${pkgs.writeScript "serve-rustc-docs" ''
+              cd ${packages.rustc.passthru.availableComponents.rustc-docs}/share/doc/rust/html/rustc
+              ${pkgs.python3}/bin/python -m http.server
+            ''}";
+          };
         };
         devShells = {
           default = pkgs.mkShell {
@@ -66,7 +75,7 @@
 
               (pkgs.stdenv.mkDerivation {
                 name = "rebuild-script";
-                phases = [ "installPhase" ];
+                phases = ["installPhase"];
                 installPhase = ''
                   mkdir -p $out/bin
                   cp ${./.utils/rebuild.sh} $out/bin/rebuild

--- a/frontend/exporter/default.nix
+++ b/frontend/exporter/default.nix
@@ -1,17 +1,25 @@
-{craneLib, stdenv, makeWrapper, lib, rustc, gcc }:
-let
+{
+  craneLib,
+  stdenv,
+  makeWrapper,
+  lib,
+  rustc,
+  gcc,
+}: let
   commonArgs = {
     version = "0.0.1";
     src = craneLib.cleanCargoSource ./.;
   };
   pname = "hax-rust-frontend";
-  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
-    pname = "${pname}-deps";
-  });
+  cargoArtifacts = craneLib.buildDepsOnly (commonArgs
+    // {
+      pname = "${pname}-deps";
+    });
 in
-craneLib.buildPackage (commonArgs // {
-  inherit cargoArtifacts pname;
-})
+  craneLib.buildPackage (commonArgs
+    // {
+      inherit cargoArtifacts pname;
+    })
 # hax // {
 #   passthru = hax.passthru or {} // {
 #     wrapped = hax-engine: stdenv.mkDerivation {
@@ -33,3 +41,4 @@ craneLib.buildPackage (commonArgs // {
 #     };
 #   };
 # }
+

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -281,7 +281,7 @@ fn translate_switch_targets<'tcx, S: BaseState<'tcx>>(
             // `true` is `1`. Thus the `otherwise` branch correspond
             // to the `then` branch.
             const FALSE: u128 = false as u128;
-            let [(FALSE, else_branch)] =  targets_vec.as_slice() else {
+            let [(FALSE, else_branch)] = targets_vec.as_slice() else {
                 supposely_unreachable_fatal!(s, "MirSwitchBool"; {targets_vec, switch_ty});
             };
 
@@ -546,7 +546,8 @@ impl<'tcx, S: BaseState<'tcx> + HasMir<'tcx>> SInto<S, Place> for rustc_middle::
                             r
                         }
                         Index(local) => {
-                            let (TyKind::Slice(ty) | TyKind::Array(ty, _)) = current_ty.kind() else {
+                            let (TyKind::Slice(ty) | TyKind::Array(ty, _)) = current_ty.kind()
+                            else {
                                 supposely_unreachable_fatal!(
                                     s, "PlaceIndexNotSlice";
                                     {current_ty, current_kind, elem}


### PR DESCRIPTION
This PR fixes all OCaml warnings across the `engine/lib` dune "package" (don't know whether that's the proper wording in the dune ecosystem).
This PR also makes warning fatal, so that I don't do this kind of PR in the future