### PR TITLE
Add a missing shebang on `generate.sh`

### DIFF
--- a/engine/lib/concrete_ident/generate.sh
+++ b/engine/lib/concrete_ident/generate.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 RUST_SOURCE=$(cat "$1")
 TEMPDIR=$(mktemp -d)
 trap '{ rm -rf -- "$TEMPDIR/"; }' EXIT


### PR DESCRIPTION
We've spend time with @R1kM trying to debug `generate.sh` while actually everything was fine with the script itself, the faulty thing was the shell it was run with.
Whence that PR, so that we don't hit the same thing again in the future