### PR TITLE
Rewrite `generate.sh` script

### DIFF
--- a/cli/options/engine/src/lib.rs
+++ b/cli/options/engine/src/lib.rs
@@ -22,3 +22,11 @@ pub struct Output {
     pub files: Vec<File>,
     pub debug_json: Option<String>,
 }
+
+// This is located here for dependency reason, but this is not related
+// to the engine (yet?).
+#[derive(JsonSchema, Debug, Clone, Serialize, Deserialize)]
+pub struct WithDefIds<Body: hax_frontend_exporter::IsBody> {
+    pub def_ids: Vec<hax_frontend_exporter::DefId>,
+    pub items: Vec<hax_frontend_exporter::Item<Body>>,
+}

--- a/cli/subcommands/build.rs
+++ b/cli/subcommands/build.rs
@@ -20,6 +20,7 @@ fn json_schema_static_asset() {
         hax_diagnostics::Diagnostics<hax_frontend_exporter::Span>,
         hax_cli_options_engine::EngineOptions,
         hax_cli_options_engine::Output,
+        hax_cli_options_engine::WithDefIds<hax_frontend_exporter::ThirBody>,
     ));
     serde_json::to_writer(
         std::fs::File::create(format!("{}/schema.json", std::env::var("OUT_DIR").unwrap()))

--- a/cli/subcommands/src/cargo_hax.rs
+++ b/cli/subcommands/src/cargo_hax.rs
@@ -59,9 +59,8 @@ fn rust_log_style() -> String {
 
 fn main() {
     let args: Vec<String> = get_args("hax");
-    // eprintln!("args: {args:?}");
-    let options = Options::parse_from(args.iter()).normalize_paths();
-    // eprintln!("options: {options:?}");
+    let mut options = Options::parse_from(args.iter());
+    options.normalize_paths();
 
     let mut cmd = Command::new("cargo");
     if let Some(toolchain) = toolchain() {

--- a/engine/lib/concrete_ident/generate.sh
+++ b/engine/lib/concrete_ident/generate.sh
@@ -11,35 +11,20 @@ cargo init --lib
 
 echo "$RUST_SOURCE" > src/lib.rs
 
-cargo hax json
-
-echo "type name = "
-mappings="let def_id_of: name -> Types.def_id = function "
-parsed=""
-
-for json in $(
-                cat hax_frontend_export.json \
-                    | jq 'paths as $p | select(getpath($p) | if type == "object" then has("krate") else false end) | getpath($p) | @base64' -cr \
-                    | sort -u
-               ); do
-    name=$(
-        echo -n "$json" | base64 --decode \
-            | jq '(.krate | ((.[0:1] | ascii_upcase) + .[1:])) + "__" + (.path | map((.data | if type == "object" then to_entries | first | .value else . end) + (.disambiguator | if . == 0 then "" else "_" + (. | tostring) end)) | join("__"))' -r
-        )
-    if [[ "$name" == *"dummy_hax_concrete_ident_wrapper"* ]]; then
-        continue
-    fi
-    echo "$enum | $name"
-    parsed=$(
-        echo "$parsed"
-        echo "let parsed_$name = Types.parse_def_id (Yojson.Safe.from_string {hax_generated_name|$(echo "$json" | base64 --decode)|hax_generated_name})"
-          )
-    mappings=$(
-        echo "$mappings "
-        echo "    | $name -> Values.parsed_$name")
-done
-
-echo "module Values = struct"
-echo "$parsed"
-echo "end"
-echo "$mappings"
+cargo hax json --def-ids -o - | jq -r "$(cat - <<JQ_SCRIPT
+  .def_ids | . as \$ids
+  | map(  (.krate | ((.[0:1] | ascii_upcase) + .[1:]))
+        + "__"
+        + ( .path | map(
+              (.data | if type == "object" then to_entries | first | .value else . end)
+            + (.disambiguator | if . == 0 then "" else "_" + (. | tostring) end)
+            ) | join("__"))) as \$names
+  | "type name = " + (\$names | join(" | \\n"))
+  + "\\nmodule Values = struct\\n"
+  + ( keys
+    | map(. as \$i | "let parsed_" + \$names[\$i] + " = Types.parse_def_id (Yojson.Safe.from_string {hax_gen_def_id|" + (\$ids[\$i] | tojson) + "|hax_gen_def_id})")
+    | join("\\n"))
+  + "end\\nlet def_id_of: name -> Types.def_id = function "
+  + (\$names | map(. + " -> Values.parsed_" + .) | join(" | \\n"))
+JQ_SCRIPT
+)"


### PR DESCRIPTION
Since #234 we are now able to extract directly in the frontend a list of definition identifiers.
Thus, this makes a part of the `generate.sh` script useless; the PR drop that useless part and simplifies the rest.

This should also help make the script more cross-platform: we recently had error reports (from @R1kM and @xvzcf notably), and I suspect those were due to `base64` behaving in a strange way on MacOS (now the generate.sh script doesn't use that anylonger).