### PR TITLE
Improve `rebuild.sh` script

### DIFF
--- a/.utils/rebuild.sh
+++ b/.utils/rebuild.sh
@@ -51,11 +51,14 @@ trap on_exit                EXIT ERR
 trap "status $RED 'SIGINT'" SIGINT
 
 CURRENT="none"
+started() { [ -z ${QUIET+x} ] && status $BLACK "$1 build started" || true; }
 if [[ "$TARGETS" == *rust* ]]; then
+    started rust
     rust
     status $GREEN "rust succeed"
 fi
 if [[ "$TARGETS" == *ml* ]]; then
+    started ocaml
     ocaml
     status $GREEN "ocaml succeed"
 fi

--- a/.utils/rebuild.sh
+++ b/.utils/rebuild.sh
@@ -13,6 +13,11 @@ fi
 
 TARGETS="${1:-rust ocaml}"
 
+YELLOW=43
+GREEN=42
+RED=41
+BLACK=40
+status () { echo -e "\e[1m[rebuild script] \e[30m\e[$1m$2\e[0m"; }
 
 cd_rootwise () {
     cd $(git rev-parse --show-toplevel)/$1
@@ -36,11 +41,17 @@ ocaml () {
     # to be in PATH anyway).
     DUNE_INSTALL_PREFIX="${DUNE_INSTALL_PREFIX:-$HOME/.cargo}"
     dune install --profile dev --prefix $DUNE_INSTALL_PREFIX
-}
 
-GREEN=42
-RED=41
-status () { echo -e "\e[1m[rebuild script] \e[30m\e[$1m$2\e[0m"; }
+    if ( command -v "which" && command -v "sort" && command -v "wc" ) >/dev/null; then
+        case $(which -a hax-engine | sort -u | wc -l) in
+            0) status $YELLOW 'Warning: cannot detect `hax-engine` in PATH';;
+            1) :;;
+            *) status $YELLOW 'Warning: multiple `hax-engine` detected in PATH. Maybe you installed Hax with OPAM (i.e. via `setup.sh`)? Please uninstall it, otherwise you might use a stale engine!';;
+        esac
+    else
+        status $YELLOW 'Warning: cannot run sanity checks because `which`, `sort` or `wc` commands are not available. Please install them.'
+    fi
+}
 
 on_exit () {
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
This PR improves the `./.utils/rebuild.sh` script:
 - add `<TASK> build started` logs;
 - add sanity checks, emit warning when, after `dune install`:
   + `hax-engine` is not in `PATH`;
   + `hax-engine` is more than once in `PATH` (happened to @R1kM, causing absolutely incomprehensible errors!).
