### PR TITLE
Revive js engine

### DIFF
--- a/engine/bin/dune
+++ b/engine/bin/dune
@@ -24,7 +24,7 @@
  (modules js_driver)
  (js_of_ocaml
   (javascript_files js_stubs/mutex.js js_stubs/stdint.js js_stubs/unix.js))
- (libraries zarith_stubs_js lib))
+ (libraries zarith_stubs_js js_of_ocaml lib))
 
 (env
  (_

--- a/engine/bin/js_driver.ml
+++ b/engine/bin/js_driver.ml
@@ -1,1 +1,85 @@
-let _ = Lib.main (Lib.read_options_from_stdin Yojson.Safe.from_string))
+open Base
+open Js_of_ocaml
+
+(* Strings are slow with js_of_ocaml. Thus, parsing a string into a
+   `Yojson.Safe.t` is extremly slow using yojson itself. Instead, I
+   wrote a very simple and stupid `yojson_of_string_via_js` that (1)
+   parses the json out of a JS string into a JS object (2) make a
+   yojson AST. This is something like x100 faster. Without this hack,
+   the performance is too bad to be bearable. *)
+let yojson_of_string_via_js (s : string) : Yojson.Safe.t =
+  let f =
+    Js.Unsafe.js_expr
+      {js|
+(function (mkNull, mkBool, mkBigint, mkInt, mkFloat, mkString, mkDict, mkArray){
+  function isInt(n) {
+    return n % 1 === 0;
+  }
+  function f(x){
+    let t = typeof x;
+    if (t === 'undefined' || x === null) {
+      return mkNull;
+    } else if (t === 'boolean') {
+      return mkBool(x);
+    } else if (t === 'object') {
+      if (x instanceof Array) {
+        return mkArray(x.map(f));
+      } else {
+        let data = Object.entries(x).map(function(o) {
+          let key = o[0];
+          let val = f(o[1]);
+          return [key, val];
+        });
+        return mkDict(data);
+      }
+    } else if (t === 'number') {
+      return mkBigint(x.toString());
+      if (isInt(x)) {
+        return mkInt(x);
+      } else {
+        return mkFloat(x);
+      }
+    } else if (t === 'bigint') {
+      return mkBigint(x.toString());
+    } else if (t === 'string') {
+      return mkString(x);
+    } else {
+      throw ("Cannot deal with " + JSON.stringify(x));
+    }
+  };
+  return (function(str){
+    let json = JSON.parse(str);
+    let result = f(json);
+    return result;
+  });
+})
+|js}
+  in
+  let open Js in
+  let open Unsafe in
+  let wrap (type a) (f : a t -> Yojson.Safe.t) =
+    inject (callback (fun x -> f (coerce x)))
+  in
+  let to_list x = to_array x |> Array.to_list in
+  let fn =
+    fun_call f
+      [|
+        inject `Null;
+        wrap (fun x -> `Bool (to_bool x));
+        wrap (fun x -> `Intlit (to_bytestring x));
+        wrap (fun x -> `Int (float_of_number x |> Float.to_int));
+        wrap (fun x -> `Float (float_of_number x));
+        wrap (fun x -> `String (to_bytestring x));
+        wrap (fun x ->
+            `Assoc
+              (to_list x
+              |> List.map ~f:(fun x ->
+                     match to_list x with
+                     | [ key; json ] -> (to_string key, Stdlib.Obj.magic json)
+                     | _ -> failwith "Assoc")));
+        wrap (fun x -> `List (to_list x));
+      |]
+  in
+  fun_call fn [| string s |> coerce |] |> Obj.magic
+
+let _ = Lib.main (Lib.read_options_from_stdin yojson_of_string_via_js)

--- a/engine/bin/js_driver.ml
+++ b/engine/bin/js_driver.ml
@@ -1,1 +1,1 @@
-let _ = Lib.main ()
+let _ = Lib.main (Lib.read_options_from_stdin Yojson.Safe.from_string))

--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -1,9 +1,10 @@
 open Hax_engine
 open Base
 
-let read_options_from_stdin () : Types.engine_options =
+let read_options_from_stdin (yojson_from_string : string -> Yojson.Safe.t) :
+    Types.engine_options =
   In_channel.input_all In_channel.stdin
-  |> Yojson.Safe.from_string |> Types.parse_engine_options
+  |> yojson_from_string |> Types.parse_engine_options
 
 let setup_logs (options : Types.engine_options) =
   let level : Logs.level option =
@@ -15,8 +16,7 @@ let setup_logs (options : Types.engine_options) =
   Logs.set_level level;
   Logs.set_reporter @@ Logs.format_reporter ()
 
-let run () : Types.output =
-  let options = read_options_from_stdin () in
+let run (options : Types.engine_options) : Types.output =
   setup_logs options;
   if options.backend.debug_engine then Phase_utils.DebugBindPhase.enable ();
   let run (type options_type)
@@ -56,10 +56,10 @@ let run () : Types.output =
     debug_json = None;
   }
 
-let main () =
+let main (options : Types.engine_options) =
   Printexc.record_backtrace true;
   let result =
-    try Ok (run ()) with e -> Error (e, Printexc.get_raw_backtrace ())
+    try Ok (run options) with e -> Error (e, Printexc.get_raw_backtrace ())
   in
   match result with
   | Ok results ->

--- a/engine/bin/lib.mli
+++ b/engine/bin/lib.mli
@@ -1,1 +1,3 @@
-val main : unit -> unit
+val read_options_from_stdin : (string -> Yojson.Safe.t) -> Hax_engine.Types.engine_options
+val main : Hax_engine.Types.engine_options -> unit
+

--- a/engine/bin/native_driver.ml
+++ b/engine/bin/native_driver.ml
@@ -1,1 +1,4 @@
-let _ = Lib.main ()
+open Hax_engine
+open Base
+
+let _ = Lib.main (Lib.read_options_from_stdin Yojson.Safe.from_string)

--- a/engine/default.nix
+++ b/engine/default.nix
@@ -63,6 +63,7 @@
         logs
         core
         re
+        js_of_ocaml
       ]
       ++
       # F* dependencies

--- a/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
+++ b/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
@@ -204,7 +204,7 @@ let ocaml_arms_of_type_expr = (o, path) => {
             ],
             int: [
                 [`\`Int i`, 'i'],
-                [`\`Intlit s`, 'failwith "Got Intlit while parsing small int"']
+                [`\`Intlit s`, 'Base.Int.of_string s']
             ]
         })[o.repr],
         name: payload => [['remains', `parse_${typeNameOf(payload)} remains`]],


### PR DESCRIPTION
First half of #261:
 - Add a few missing features to the JSON schema to OCaml script;
 - Use native JS JSON parser while compiling the engine with JS.