### PR TITLE
refactor(engine/ast): `*i_name: string` -> `*i_ident: concrete_ident`

### DIFF
--- a/engine/backends/coq/coq/coq_backend.ml
+++ b/engine/backends/coq/coq/coq_backend.ml
@@ -534,7 +534,7 @@ struct
             ( U.Concrete_ident_view.to_definition_name name,
               List.map
                 ~f:(fun x ->
-                  ( x.ti_name,
+                  ( U.Concrete_ident_view.to_definition_name x.ti_ident,
                     match x.ti_v with
                     | TIFn fn_ty -> pty span fn_ty
                     | _ -> __TODO_ty__ span "field_ty" ))
@@ -561,7 +561,7 @@ struct
                 ~f:(fun x ->
                   match x.ii_v with
                   | IIFn { body; params } ->
-                      ( x.ii_name,
+                      ( U.Concrete_ident_view.to_definition_name x.ii_ident,
                         List.map
                           ~f:(fun { pat; typ; typ_span } ->
                             (ppat pat, pty span typ))

--- a/engine/backends/fstar/fstar_ast.ml
+++ b/engine/backends/fstar/fstar_ast.ml
@@ -39,6 +39,9 @@ let pat_var_tcresolve (var : string option) =
 let pat_app name l = pat @@ AST.PatApp (name, l)
 let wild = pat @@ AST.PatWild (None, [])
 
+let mk_e_abs args body =
+  if List.is_empty args then body else term (AST.Abs (args, body))
+
 let mk_e_app base args =
   AST.mkApp base (List.map ~f:(fun arg -> (arg, AST.Nothing)) args) dummyRange
 

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -437,7 +437,7 @@ struct
           (F.term @@ F.AST.Name (pglobal_ident e.span constructor))
           [ r ]
     | Closure { params; body } ->
-        F.term @@ F.AST.Abs (List.map ~f:ppat params, pexpr body)
+        F.mk_e_abs (List.map ~f:ppat params) (pexpr body)
     | Return { e } ->
         F.term @@ F.AST.App (F.term_of_lid [ "RETURN_STMT" ], pexpr e, Nothing)
     | MacroInvokation { macro; args; witness } ->
@@ -818,7 +818,7 @@ struct
         let fields =
           List.concat_map
             ~f:(fun i ->
-              let name = map_first_letter String.lowercase @@ i.ti_name in
+              let name = U.Concrete_ident_view.to_definition_name i.ti_ident in
               match i.ti_v with
               | TIType bounds ->
                   let t = F.term @@ F.AST.Name (F.lid [ "Type" ]) in
@@ -859,35 +859,35 @@ struct
             (List.map ~f:(pgeneric_value e.span) generic_args)
         in
         let pat = F.pat @@ F.AST.PatAscribed (pat, (typ, None)) in
-        let body =
-          F.term
-          @@ F.AST.Record
-               ( None,
-                 List.map
-                   ~f:(fun { ii_span; ii_generics; ii_v; ii_name } ->
-                     ( F.lid [ map_first_letter String.lowercase @@ ii_name ],
-                       match ii_v with
-                       | IIFn { body; params } ->
-                           let pats =
-                             List.map ~f:(pgeneric_param ii_span)
-                               generics.params
-                             @ List.mapi
-                                 ~f:(pgeneric_constraint ii_span)
-                                 generics.constraints
-                             @ List.map
-                                 ~f:(fun { pat; typ_span; typ } ->
-                                   let span =
-                                     Option.value ~default:ii_span typ_span
-                                   in
-                                   F.pat
-                                   @@ F.AST.PatAscribed
-                                        (ppat pat, (pty span typ, None)))
-                                 params
-                           in
-                           F.term @@ F.AST.Abs (pats, pexpr body)
-                       | IIType ty -> pty ii_span ty ))
-                   items )
+        let fields =
+          List.map
+            ~f:(fun { ii_span; ii_generics; ii_v; ii_ident } ->
+              let name = U.Concrete_ident_view.to_definition_name ii_ident in
+              ( F.lid [ name ],
+                match ii_v with
+                | IIFn { body; params } ->
+                    let pats =
+                      List.map ~f:(pgeneric_param ii_span) generics.params
+                      @ List.mapi
+                          ~f:(pgeneric_constraint ii_span)
+                          generics.constraints
+                      @ List.map
+                          ~f:(fun { pat; typ_span; typ } ->
+                            let span = Option.value ~default:ii_span typ_span in
+                            F.pat
+                            @@ F.AST.PatAscribed (ppat pat, (pty span typ, None)))
+                          params
+                    in
+                    F.mk_e_abs pats (pexpr body)
+                | IIType ty -> pty ii_span ty ))
+            items
         in
+        let fields =
+          if List.is_empty fields then
+            [ (F.lid [ "__marker_trait" ], pexpr (U.unit_expr e.span)) ]
+          else fields
+        in
+        let body = F.term @@ F.AST.Record (None, fields) in
         F.decls @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, body) ])
     | HaxError details -> [ `Comment details ]
     | Use _ (* TODO: Not Yet Implemented *) | NotImplementedYet -> []

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -599,7 +599,7 @@ functor
       ii_span : span;
       ii_generics : generics;
       ii_v : impl_item';
-      ii_name : string;
+      ii_ident : concrete_ident;
       ii_attrs : attrs;
     }
 
@@ -610,7 +610,7 @@ functor
       ti_span : span;
       ti_generics : generics;
       ti_v : trait_item';
-      ti_name : string;
+      ti_ident : concrete_ident;
       ti_attrs : attrs;
     }
     [@@deriving

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -327,7 +327,7 @@ struct
         ti_span = ti.ti_span;
         ti_generics = dgenerics ti.ti_span ti.ti_generics;
         ti_v = dtrait_item' ti.ti_span ti.ti_v;
-        ti_name = ti.ti_name;
+        ti_ident = ti.ti_ident;
         ti_attrs = ti.ti_attrs;
       }
 
@@ -342,7 +342,7 @@ struct
         ii_span = ii.ii_span;
         ii_generics = dgenerics ii.ii_span ii.ii_generics;
         ii_v = dimpl_item' ii.ii_span ii.ii_v;
-        ii_name = ii.ii_name;
+        ii_ident = ii.ii_ident;
         ii_attrs = ii.ii_attrs;
       }
 


### PR DESCRIPTION
As @cmester0 noticed some while ago, `ti_name` and `ii_name` are strings while any other global identity is usually a `concrete_ident` (or a `global_ident` when that makes sense).
This PR renames and retypes the fields `ti_name` and `ii_name` into `ti_ident` and `ii_ident`.