### PR TITLE
fix(driver): stop rustc compilation after running Hax

### DIFF
--- a/cli/driver/src/exporter.rs
+++ b/cli/driver/src/exporter.rs
@@ -478,7 +478,7 @@ impl Callbacks for ExtractionCallbacks {
                     }
                 }
             };
-            Compilation::Continue
+            Compilation::Stop
         })
     }
 }


### PR DESCRIPTION
Currently, the driver keeps going and lets Rustc compile all the way to binary production.
That's not what we want, since doing that triggers the borrow checker: for annotations we really don't want the borrow checker to run.