### PR TITLE
fix(engine/import-thir): fix kind of impl ids

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -868,7 +868,7 @@ end) : EXPR = struct
     in
     match ie with
     | Concrete { id; generics } ->
-        let trait = Concrete_ident.of_def_id Trait id in
+        let trait = Concrete_ident.of_def_id Impl id in
         let args = List.map ~f:(c_generic_value span) generics in
         Concrete { trait; args }
     | LocalBound { clause_id; path } ->


### PR DESCRIPTION
This PR changes the kind of impl identifiers in impl expressions.
(the name of an impl `foo` was outputted as `t_foo` instead of `i_foo`)